### PR TITLE
interpret sprintf args in types-base #3

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -1382,33 +1382,33 @@ func (p *Interp) sprintf(format string, args []value) string {
 	if err != nil {
 		panic(newError("format error: %s", err))
 	}
-	if len(types) != len(args) {
+	if len(types) > len(args) {
 		panic(newError("format error: got %d args, expected %d", len(args), len(types)))
 	}
-	converted := make([]interface{}, len(args))
-	for i, a := range args {
+	converted := make([]interface{}, len(types))
+	for i, t := range types {
 		var v interface{}
-		switch types[i] {
+		switch t {
 		case 'd':
-			v = int(a.num())
+			v = int(args[i].num())
 		case 'u':
-			v = uint32(a.num())
+			v = uint32(args[i].num())
 		case 'c':
 			var c []byte
-			if a.isTrueStr() {
-				s := p.toString(a)
+			if args[i].isTrueStr() {
+				s := p.toString(args[i])
 				if len(s) > 0 {
 					c = []byte{s[0]}
 				}
 			} else {
-				r := []rune{rune(a.num())}
+				r := []rune{rune(args[i].num())}
 				c = []byte(string(r))
 			}
 			v = c
 		case 'f':
-			v = a.num()
+			v = args[i].num()
 		case 's':
-			v = p.toString(a)
+			v = p.toString(args[i])
 		}
 		converted[i] = v
 	}


### PR DESCRIPTION
#3 
Original-awk accepts extra arguments. 
And I found sprintf in interp.go is argment-based interpret, so I fix types-based(array which format specifiers) interpret.
If the number of format specifiers is more than the num of argments, it shows format error message and exit 1.
```
[yugo-horie@goawk 10:53:06]$go run goawk.go 'BEGIN { sprintf("%d ", 1, 2) }'
[yugo-horie@goawk 10:54:17]$go run goawk.go 'BEGIN { sprintf("%d %d", 1, 2) }'
[yugo-horie@goawk 10:54:22]$go run goawk.go 'BEGIN { sprintf("%d %d %d", 1, 2) }'
format error: got 2 args, expected 3
exit status 1
```
If it's looks good for you please merge it.