### PR TITLE
add syntax sugar to support JSON array/object value

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -1013,6 +1013,11 @@ func (p *interp) setArrayValue(scope VarScope, arrayIndex int, index string, v v
 	p.arrays[resolved][index] = v
 }
 
+func (p *interp) setJArray(scope VarScope, arrayIndex int, v value) {
+	resolved := p.getArrayIndex(scope, arrayIndex)
+	p.arrays[resolved] = v.jArray()
+}
+
 // Get the value of given numbered field, equivalent to "$index"
 func (p *interp) getField(index int) (value, error) {
 	if index < 0 {
@@ -1173,6 +1178,12 @@ func (p *interp) assign(left Expr, right value) error {
 	case *VarExpr:
 		return p.setVar(left.Scope, left.Index, right)
 	case *IndexExpr:
+		// for JSON object, added by rosbit
+		if right.isJArray() {
+			p.setJArray(left.Array.Scope, left.Array.Index, right)
+			return nil
+		}
+		// end for JSON object
 		index, err := p.evalIndex(left.Index)
 		if err != nil {
 			return err

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -72,6 +72,11 @@ const (
 	RETURN
 	WHILE
 
+	// Syntax sugar
+	VAR        // indicate an array variable declared as JSON array or object
+	F_JARRAY   // [a, b, c]  -> _jarray_(a, b, c) -> _jobject_(1,a, 2,b, 3,c)
+	F_JOBJECT  // {a:1, b:2} -> _jobject_(a,1, b,2)
+
 	// Built-in functions
 	F_ATAN2
 	F_CLOSE
@@ -99,6 +104,8 @@ const (
 	NAME
 	NUMBER
 	STRING
+	TRUE
+	FALSE
 	REGEX
 
 	LAST       = REGEX
@@ -125,6 +132,9 @@ var keywordTokens = map[string]Token{
 	"printf":   PRINTF,
 	"return":   RETURN,
 	"while":    WHILE,
+	"true":     TRUE,
+	"false":    FALSE,
+	"var":      VAR,
 
 	"atan2":   F_ATAN2,
 	"close":   F_CLOSE,
@@ -213,6 +223,12 @@ var tokenNames = map[Token]string{
 	PRINTF:   "printf",
 	RETURN:   "return",
 	WHILE:    "while",
+	TRUE:     "true",
+	FALSE:    "false",
+	VAR:      "var",
+
+	F_JARRAY:  "_jarray_",
+	F_JOBJECT: "_jobject_",
 
 	F_ATAN2:   "atan2",
 	F_CLOSE:   "close",


### PR DESCRIPTION
because awk doesn't support literal JSON object, it is very tedious to create an array variable like this:
```awk
   a["f1"] = 1
   a["f2"] = 2
   a["f3"] = 3
```

I added two syntax sugars to write literal JSON object. The changes includes:
 1.  add a keyword "var" to indicate the following NAME is an array variable name
 2. add some tokens, they are "true", "false", F_JARRAY, F_JOBJECT
 3. F_JARRAY and J_OBJECT are implemented as built-in functions to wrapper arguments to array values
 4. expand value struct in interp package to support value type "map[string]value"

now we can write literal JSON object in awk like the following:
```javascript
  var a = {
       f1: 1, f2: 2, f3:3,
       "a": true, "b": [1, 3, 4]
  }
```

and we can  refer the variable by index like
 `print a["f1"]`

If you think this is useful, merge it to the master trunk. Thank you!

Rosbit Xu.