### PR TITLE
Avoid type checking for config func and config var

### DIFF
--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -257,7 +257,11 @@ func (p *parser) resolveVars(prog *Program) {
 					continue
 				}
 				if info.typ == typeUnknown {
-					paramName := prog.Functions[p.functions[info.callName]].Params[info.argIndex]
+					fIndex, exists := p.functions[info.callName]
+					if !exists {
+						continue
+					}
+					paramName := prog.Functions[fIndex].Params[info.argIndex]
 					typ := p.varTypes[info.callName][paramName].typ
 					if typ != typeUnknown {
 						if p.debugTypes {


### PR DESCRIPTION
Type checking was broken (caused a panic) when both the function and the variable used as an argument to a function are defined via config.

This commit simply removes the type check in this particular case. Ideally we would instead perform type checking based on the reflection derived types from the config based functions.