### PR TITLE
Add config options for "safe mode" to prevent exec and file reads/writes

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,3 @@
-* should interp have a configurable "safe" mode that doesn't run
-  system(), redirection, etc?
 * support "getline lvalue"
 * fix how we handle numstr type when setting $0 directly, see TODO test:
   {`BEGIN { $0="0"; print !$0 }`, "", "0\n", "", ""},

--- a/goawk.go
+++ b/goawk.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	version = "v1.3.0"
+	version = "v1.4.0"
 )
 
 func main() {

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -188,6 +188,9 @@ func (p *interp) callBuiltin(op Token, argExprs []Expr) (value, error) {
 		return num(prevSeed), nil
 
 	case F_SYSTEM:
+		if p.noExec {
+			return null(), newError("can't call system() due to NoExec")
+		}
 		cmdline := p.toString(args[0])
 		cmd := exec.Command("sh", "-c", cmdline)
 		stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
This is useful for running scripts from untrusted user input.