### PR TITLE
support @n to express AWK ouput field n, which the semantics of $n

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -118,7 +118,15 @@ func (l *Lexer) scan() (Position, Token, string) {
 	// through a corpus of real AWK programs to determine actual
 	// frequency.
 	switch ch {
-	case '$':
+	// There are many cases, $1/$2/... means argv1/argv2/...
+	// In order to distinguish between $n and argv[N] in this case,
+	// it will be helpful to support @n to express AWK ouput field n,
+	// which the semantics of $n
+
+	// Example (Windows OS)
+	// echo a = 100 | goawk "{ print @3 }" will print 100, same as
+	// echo a = 100 | goawk "{ print $3 }" will print 100
+	case '$', '@':
 		tok = DOLLAR
 	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.':
 		// Avoid make/append and use l.offset directly for performance


### PR DESCRIPTION
There are many cases, $1/$2/... means arg1/arg2/..., for example, Cmder let us to set alias mycp=cp $1 $2 and then use mycp src dst. In this case, $1=src $2=dst

Consider this case, opengiturl=cat .git\config | grep https | goawk "{ print $3 }", here $3 will be set to arg3 of command line "opengiturl arg1 arg2 arg3".  If we try command "opengiturl", $3 will be empty string. But in this case, we expect goawk "{ print $3 }" will print third field output of goawk, which is "https://github.com/lilixiong2018/goawk.git", not arg3.

this commit support @n to express AWK ouput field n, if we let opengiturl=cat .git\config | grep https | goawk "{ print @3 }", and try command "opengiturl", it will print "https://github.com/benhoyt/goawk.git" as expect.