### PR TITLE
Support wildcard expansion on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/benhoyt/goawk
 
 go 1.13
+
+require github.com/mattn/getwild v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/getwild v0.0.1 h1:+Nlzxt7fonj2MtO9y/rg5hxOnM3H6tuTqeD38W25jfo=
+github.com/mattn/getwild v0.0.1/go.mod h1:AG+GKQydHp7iLJn+VV+D7y8LeYs5bQ0Xz4fmKd5o1Sg=

--- a/goawk_windows.go
+++ b/goawk_windows.go
@@ -1,0 +1,3 @@
+package main
+
+import _ "github.com/mattn/getwild"


### PR DESCRIPTION
On Windows, since the standard shell CMD.EXE and PowerShell do not expand arguments including wildcards, the some applications have to do instead of shells.

The package [getwild](https://github.com/mattn/getwild) expands wildcards just by importing it.
( The name "getwild" means the Japanese popular song. )

I made the patch using [getwild](https://github.com/mattn/getwild) for goawk . If my patch does not have problems , would you merge ?

Before:

```
$ goawk "FNR==1 { print FILENAME }" *.go
open *.go: The filename, directory name, or volume label syntax is incorrect.
```

After:

```
$ goawk "FNR==1 { print FILENAME }" *.go
goawk.go
goawk_test.go
goawk_windows.go
```