### PR TITLE
Fix random seed

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -192,6 +192,11 @@ type Config struct {
 	NoFileReads  bool
 }
 
+var (
+	randSeed = float64(time.Now().UnixNano())
+	randSrc  = rand.NewSource(int64(math.Float64bits(randSeed)))
+)
+
 // ExecProgram executes the parsed program using the given interpreter
 // config, returning the exit status code of the program. Error is nil
 // on successful execution of the program, even if the program returns
@@ -214,9 +219,8 @@ func ExecProgram(program *Program, config *Config) (int, error) {
 	// Initialize defaults
 	p.regexCache = make(map[string]*regexp.Regexp, 10)
 	p.formatCache = make(map[string]cachedFormat, 10)
-	p.randSeed = float64(time.Now().UnixNano())
-	seed := math.Float64bits(p.randSeed)
-	p.random = rand.New(rand.NewSource(int64(seed)))
+	p.randSeed = randSeed
+	p.random = rand.New(randSrc)
 	p.convertFormat = "%.6g"
 	p.outputFormat = "%.6g"
 	p.fieldSep = " "

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	. "github.com/benhoyt/goawk/internal/ast"
@@ -213,7 +214,7 @@ func ExecProgram(program *Program, config *Config) (int, error) {
 	// Initialize defaults
 	p.regexCache = make(map[string]*regexp.Regexp, 10)
 	p.formatCache = make(map[string]cachedFormat, 10)
-	p.randSeed = 1.0
+	p.randSeed = float64(time.Now().UnixNano())
 	seed := math.Float64bits(p.randSeed)
 	p.random = rand.New(rand.NewSource(int64(seed)))
 	p.convertFormat = "%.6g"


### PR DESCRIPTION
First of all: thank you for this library! It's fantastic.

While working with it I've found that the RNG in `ExecProgram` was always initialised with the same static values, meaning that every time I've run a simple program like `BEGIN { print rand() }` it was printing `0.606997` every single time.

This PR changes the RNG generation to one with a time-based seed, and while at it it also does it by computing the initial seed and random source outside the `ExecProgram`. Doing this still passes the tests that I've added for proving we always get different values, but also reduces the execution time in 80%. I've run the benchmarks 40 times and then used [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare the results:

```
name            old time/op    new time/op    delta
BuiltinRand-12    10.5µs ± 1%     2.0µs ± 3%  -81.21%  (p=0.000 n=34+36)

name            old alloc/op   new alloc/op   delta
BuiltinRand-12    11.8kB ± 0%     6.4kB ± 0%  -45.69%  (p=0.000 n=40+40)

name            old allocs/op  new allocs/op  delta
BuiltinRand-12      18.0 ± 0%      17.0 ± 0%   -5.56%  (p=0.000 n=40+40)
```