### PR TITLE
Add ShellCommand config option and change default to /bin/sh (on Unix)

### DIFF
--- a/interp/functions.go
+++ b/interp/functions.go
@@ -192,7 +192,7 @@ func (p *interp) callBuiltin(op Token, argExprs []Expr) (value, error) {
 			return null(), newError("can't call system() due to NoExec")
 		}
 		cmdline := p.toString(args[0])
-		cmd := exec.Command("/bin/sh", "-c", cmdline)
+		cmd := p.execShell(cmdline)
 		cmd.Stdout = p.output
 		cmd.Stderr = p.errorOutput
 		err := cmd.Start()
@@ -261,6 +261,15 @@ func (p *interp) callBuiltin(op Token, argExprs []Expr) (value, error) {
 	}
 }
 
+// executes code using configured system shell
+func (p *interp) execShell(code string) *exec.Cmd {
+	shellInterpreter := p.shellCommand[0]
+	shellArgs := p.shellCommand[1:]
+	shellArgs = append(shellArgs, code)
+	cmd := exec.Command(shellInterpreter, shellArgs...)
+	return cmd
+}
+
 // Call user-defined function with given index and arguments, return
 // its return value (or null value if it doesn't return anything)
 func (p *interp) callUser(index int, args []Expr) (value, error) {
@@ -320,11 +329,11 @@ func (p *interp) callUser(index int, args []Expr) (value, error) {
 	return null(), nil
 }
 
-// Call native-defined function with given name and arguments, return
+// Call native-defined function with given name and arguments,
 // return value (or null value if it doesn't return anything).
 func (p *interp) callNative(index int, args []Expr) (value, error) {
 	f := p.nativeFuncs[index]
-	minIn := len(f.in) // Mininum number of args we should pass
+	minIn := len(f.in) // Minimum number of args we should pass
 	var variadicType reflect.Type
 	if f.isVariadic {
 		variadicType = f.in[len(f.in)-1].Elem()

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -261,12 +261,12 @@ func (p *interp) callBuiltin(op Token, argExprs []Expr) (value, error) {
 	}
 }
 
-// executes code using configured system shell
+// Executes code using configured system shell
 func (p *interp) execShell(code string) *exec.Cmd {
-	shellInterpreter := p.shellCommand[0]
-	shellArgs := p.shellCommand[1:]
-	shellArgs = append(shellArgs, code)
-	cmd := exec.Command(shellInterpreter, shellArgs...)
+	executable := p.shellCommand[0]
+	args := p.shellCommand[1:]
+	args = append(args, code)
+	cmd := exec.Command(executable, args...)
 	return cmd
 }
 
@@ -329,8 +329,8 @@ func (p *interp) callUser(index int, args []Expr) (value, error) {
 	return null(), nil
 }
 
-// Call native-defined function with given name and arguments,
-// return value (or null value if it doesn't return anything).
+// Call native-defined function with given name and arguments, return
+// its return value (or null value if it doesn't return anything).
 func (p *interp) callNative(index int, args []Expr) (value, error) {
 	f := p.nativeFuncs[index]
 	minIn := len(f.in) // Minimum number of args we should pass

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -192,7 +192,7 @@ func (p *interp) callBuiltin(op Token, argExprs []Expr) (value, error) {
 			return null(), newError("can't call system() due to NoExec")
 		}
 		cmdline := p.toString(args[0])
-		cmd := exec.Command("sh", "-c", cmdline)
+		cmd := exec.Command("/bin/sh", "-c", cmdline)
 		cmd.Stdout = p.output
 		cmd.Stderr = p.errorOutput
 		err := cmd.Start()

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -76,6 +76,7 @@ type interp struct {
 	noExec        bool
 	noFileWrites  bool
 	noFileReads   bool
+	shellCommand  []string
 
 	// Scalars, arrays, and function state
 	globals     []value
@@ -189,6 +190,10 @@ type Config struct {
 	NoExec       bool
 	NoFileWrites bool
 	NoFileReads  bool
+
+	// Exec args used to run system shell. Typically, this will
+	// be {"/bin/sh", "-c"}
+	ShellCommand []string
 }
 
 // ExecProgram executes the parsed program using the given interpreter
@@ -245,6 +250,19 @@ func ExecProgram(program *Program, config *Config) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+	}
+
+	// Setup system shell command
+	if len(config.ShellCommand) != 0 {
+		p.shellCommand = config.ShellCommand
+	} else {
+		var shellInterpreter string
+		if runtime.GOOS == "windows" {
+			shellInterpreter = "sh"
+		} else {
+			shellInterpreter = "/bin/sh"
+		}
+		p.shellCommand = []string{shellInterpreter, "-c"}
 	}
 
 	// Setup I/O structures

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -256,13 +256,11 @@ func ExecProgram(program *Program, config *Config) (int, error) {
 	if len(config.ShellCommand) != 0 {
 		p.shellCommand = config.ShellCommand
 	} else {
-		var shellInterpreter string
+		executable := "/bin/sh"
 		if runtime.GOOS == "windows" {
-			shellInterpreter = "sh"
-		} else {
-			shellInterpreter = "/bin/sh"
+			executable = "sh"
 		}
-		p.shellCommand = []string{shellInterpreter, "-c"}
+		p.shellCommand = []string{executable, "-c"}
 	}
 
 	// Setup I/O structures

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1033,7 +1033,12 @@ func TestConfigVarsCorrect(t *testing.T) {
 func TestShellCommand(t *testing.T) {
 	testGoAWK(t, `BEGIN { system("echo hello world") }`, "", "hello world\n", "", nil, nil)
 
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS == "windows" {
+		testGoAWK(t, `BEGIN { system("echo hello world") }`, "", "hello world\n", "", nil,
+			func(config *interp.Config) {
+				config.ShellCommand = []string{"cmd.exe", "/c"}
+			})
+	} else {
 		testGoAWK(t, `BEGIN { system("world") }`, "", "hello world\n", "", nil,
 			func(config *interp.Config) {
 				config.ShellCommand = []string{"/bin/echo", "hello"}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1026,6 +1027,25 @@ func TestConfigVarsCorrect(t *testing.T) {
 	expected := "length of config.Vars must be a multiple of 2, not 1"
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error %q, got: %v", expected, err)
+	}
+}
+
+func TestShellCommand(t *testing.T) {
+	testGoAWK(t, `BEGIN { system("echo hello world") }`, "", "hello world\n", "", nil, nil)
+
+	if runtime.GOOS != "windows" {
+		testGoAWK(t, `BEGIN { system("world") }`, "", "hello world\n", "", nil,
+			func(config *interp.Config) {
+				config.ShellCommand = []string{"/bin/echo", "hello"}
+			})
+		testGoAWK(t, `BEGIN { "world" | getline; print }`, "", "hello world\n", "", nil,
+			func(config *interp.Config) {
+				config.ShellCommand = []string{"/bin/echo", "hello"}
+			})
+		testGoAWK(t, `BEGIN { print "hello world" | "-" }`, "", "hello world\n", "", nil,
+			func(config *interp.Config) {
+				config.ShellCommand = []string{"/bin/cat"}
+			})
 	}
 }
 

--- a/interp/io.go
+++ b/interp/io.go
@@ -96,7 +96,7 @@ func (p *interp) getOutputStream(redirect Token, dest Expr) (io.Writer, error) {
 		if p.noExec {
 			return nil, newError("can't write to pipe due to NoExec")
 		}
-		cmd := exec.Command("sh", "-c", name)
+		cmd := exec.Command("/bin/sh", "-c", name)
 		w, err := cmd.StdinPipe()
 		if err != nil {
 			return nil, newError("error connecting to stdin pipe: %v", err)
@@ -160,7 +160,7 @@ func (p *interp) getInputScannerPipe(name string) (*bufio.Scanner, error) {
 	if p.noExec {
 		return nil, newError("can't read from pipe due to NoExec")
 	}
-	cmd := exec.Command("sh", "-c", name)
+	cmd := exec.Command("/bin/sh", "-c", name)
 	cmd.Stdin = p.stdin
 	cmd.Stderr = p.errorOutput
 	r, err := cmd.StdoutPipe()

--- a/interp/io.go
+++ b/interp/io.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -96,7 +95,7 @@ func (p *interp) getOutputStream(redirect Token, dest Expr) (io.Writer, error) {
 		if p.noExec {
 			return nil, newError("can't write to pipe due to NoExec")
 		}
-		cmd := exec.Command("/bin/sh", "-c", name)
+		cmd := p.execShell(name)
 		w, err := cmd.StdinPipe()
 		if err != nil {
 			return nil, newError("error connecting to stdin pipe: %v", err)
@@ -160,7 +159,7 @@ func (p *interp) getInputScannerPipe(name string) (*bufio.Scanner, error) {
 	if p.noExec {
 		return nil, newError("can't read from pipe due to NoExec")
 	}
-	cmd := exec.Command("/bin/sh", "-c", name)
+	cmd := p.execShell(name)
 	cmd.Stdin = p.stdin
 	cmd.Stderr = p.errorOutput
 	r, err := cmd.StdoutPipe()


### PR DESCRIPTION
Attempt at fixing #59.

I checked the test suite (`go test ./... -v`) - seems all green.
1. Though I feel would be good to add some more tests for this specific case, but I'm a bit unsure how exactly. The test suite in `interp_test.go` doen't have means for provinding environment variables to test. Would be glad for an advice.
2. Hopefully I changed `sh` -> `/bin/sh` in all relevant places (to cover `system()`, `"cmd" | getline`, `print | "cmd"`). But now it feels like a bit of copy-paste. Do you think it makes sense to do something about this - like extracting a function or a constant? If yes, my concern is - what is better place for it, since the change is in two files, but it doesn't feel right to complicate things much for little reason.