### PR TITLE
Addresses some IDE warnings relating to GoDoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ if err != nil {
 // baz
 ```
 
-Or you can use the `parser` module and then `interp.ExecProgram()` to control execution, set variables, etc.:
+Or you can use the `parser` module and then `interp.ExecProgram()` to control execution, set variables, and so on:
 
 ```go
 src := "{ print NR, tolower($0) }"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ if err != nil {
 // baz
 ```
 
-Or you can use the `parser` module and then `interp.ExecProgram()` to control execution, set variables, etc:
+Or you can use the `parser` module and then `interp.ExecProgram()` to control execution, set variables, etc.:
 
 ```go
 src := "{ print NR, tolower($0) }"

--- a/goawk.go
+++ b/goawk.go
@@ -67,7 +67,7 @@ Additional GoAWK arguments:
 
 func main() {
 	// Parse command line arguments manually rather than using the
-	// "flag" package so we can support flags with no space between
+	// "flag" package, so we can support flags with no space between
 	// flag and argument, like '-F:' (allowed by POSIX)
 	var progFiles []string
 	var vars []string

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -456,7 +456,7 @@ func (s *WhileStmt) String() string {
 	return "while (" + trimParens(s.Cond.String()) + ") {\n" + s.Body.String() + "}"
 }
 
-// DoWhileStmt is a fo-while loop.
+// DoWhileStmt is a do-while loop.
 type DoWhileStmt struct {
 	Body Stmts
 	Cond Expr

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -72,7 +72,7 @@ func (e *UserCallExpr) expr()  {}
 func (e *MultiExpr) expr()     {}
 func (e *GetlineExpr) expr()   {}
 
-// Field expression like $0.
+// FieldExpr is an expression like $0.
 type FieldExpr struct {
 	Index Expr
 }
@@ -81,7 +81,7 @@ func (e *FieldExpr) String() string {
 	return "$" + e.Index.String()
 }
 
-// Unary expression like -1234.
+// UnaryExpr is an expression like -1234.
 type UnaryExpr struct {
 	Op    Token
 	Value Expr
@@ -91,7 +91,7 @@ func (e *UnaryExpr) String() string {
 	return e.Op.String() + e.Value.String()
 }
 
-// Binary expression like 1 + 2.
+// BinaryExpr is an expression like 1 + 2.
 type BinaryExpr struct {
 	Left  Expr
 	Op    Token
@@ -108,8 +108,9 @@ func (e *BinaryExpr) String() string {
 	return "(" + e.Left.String() + opStr + e.Right.String() + ")"
 }
 
-// Array reference. Not really a stand-alone expression, except as
-// an argument to split() or a user function call.
+// ArrayExpr is an array reference. Not really a stand-alone
+// expression, except as an argument to split() or a user function
+// call.
 type ArrayExpr struct {
 	Scope VarScope
 	Index int
@@ -120,7 +121,7 @@ func (e *ArrayExpr) String() string {
 	return e.Name
 }
 
-// In expression like (index in array).
+// InExpr is an expression like (index in array).
 type InExpr struct {
 	Index []Expr
 	Array *ArrayExpr
@@ -137,7 +138,7 @@ func (e *InExpr) String() string {
 	return "((" + strings.Join(indices, ", ") + ") in " + e.Array.String() + ")"
 }
 
-// Conditional expression like cond ? 1 : 0.
+// CondExpr is an expression like cond ? 1 : 0.
 type CondExpr struct {
 	Cond  Expr
 	True  Expr
@@ -148,7 +149,7 @@ func (e *CondExpr) String() string {
 	return "(" + e.Cond.String() + " ? " + e.True.String() + " : " + e.False.String() + ")"
 }
 
-// Literal number like 1234.
+// NumExpr is a literal number like 1234.
 type NumExpr struct {
 	Value float64
 }
@@ -157,7 +158,7 @@ func (e *NumExpr) String() string {
 	return fmt.Sprintf("%.6g", e.Value)
 }
 
-// Literal string like "foo".
+// StrExpr is a literal string like "foo".
 type StrExpr struct {
 	Value string
 }
@@ -166,7 +167,8 @@ func (e *StrExpr) String() string {
 	return strconv.Quote(e.Value)
 }
 
-// Stand-alone regex expression, equivalent to: $0 ~ /regex/.
+// RegExpr is a stand-alone regex expression, equivalent to:
+// $0 ~ /regex/.
 type RegExpr struct {
 	Regex string
 }
@@ -184,9 +186,9 @@ const (
 	ScopeLocal
 )
 
-// Variable reference (special var, global, or local). Index is the
-// resolved variable index used by the interpreter; Name is the
-// original name used by String().
+// VarExpr is a variable reference (special var, global, or local).
+// Index is the resolved variable index used by the interpreter; Name
+// is the original name used by String().
 type VarExpr struct {
 	Scope VarScope
 	Index int
@@ -197,7 +199,7 @@ func (e *VarExpr) String() string {
 	return e.Name
 }
 
-// Index expression like a[k] (rvalue or lvalue).
+// IndexExpr is an expression like a[k] (rvalue or lvalue).
 type IndexExpr struct {
 	Array *ArrayExpr
 	Index []Expr
@@ -211,7 +213,7 @@ func (e *IndexExpr) String() string {
 	return e.Array.String() + "[" + strings.Join(indices, ", ") + "]"
 }
 
-// Assignment expression like x = 1234.
+// AssignExpr is an expression like x = 1234.
 type AssignExpr struct {
 	Left  Expr // can be one of: var, array[x], $n
 	Right Expr
@@ -221,7 +223,7 @@ func (e *AssignExpr) String() string {
 	return e.Left.String() + " = " + e.Right.String()
 }
 
-// Augmented assignment expression like x += 5.
+// AugAssignExpr is an assignment expression like x += 5.
 type AugAssignExpr struct {
 	Left  Expr // can be one of: var, array[x], $n
 	Op    Token
@@ -232,7 +234,7 @@ func (e *AugAssignExpr) String() string {
 	return e.Left.String() + " " + e.Op.String() + "= " + e.Right.String()
 }
 
-// Increment or decrement expression like x++ or --y.
+// IncrExpr is an increment or decrement expression like x++ or --y.
 type IncrExpr struct {
 	Expr Expr
 	Op   Token
@@ -247,7 +249,7 @@ func (e *IncrExpr) String() string {
 	}
 }
 
-// Builtin function call like length($1).
+// CallExpr is a builtin function call like length($1).
 type CallExpr struct {
 	Func Token
 	Args []Expr
@@ -261,9 +263,10 @@ func (e *CallExpr) String() string {
 	return e.Func.String() + "(" + strings.Join(args, ", ") + ")"
 }
 
-// User-defined function call like my_func(1, 2, 3). Index is the
-// resolved function index used by the interpreter; Name is the
-// original name used by String().
+// UserCallExpr is a user-defined function call like my_func(1, 2, 3)
+//
+// Index is the resolved function index used by the interpreter; Name
+// is the original name used by String().
 type UserCallExpr struct {
 	Native bool // false = AWK-defined function, true = native Go func
 	Index  int
@@ -293,7 +296,7 @@ func (e *MultiExpr) String() string {
 	return "(" + strings.Join(exprs, ", ") + ")"
 }
 
-// Getline expression (read from file or pipe input).
+// GetlineExpr is an expression read from file or pipe input.
 type GetlineExpr struct {
 	Command Expr
 	Var     *VarExpr
@@ -350,7 +353,7 @@ func (s *DeleteStmt) stmt()   {}
 func (s *ReturnStmt) stmt()   {}
 func (s *BlockStmt) stmt()    {}
 
-// Print statement like print $1, $3.
+// PrintStmt is a statement like print $1, $3.
 type PrintStmt struct {
 	Args     []Expr
 	Redirect Token
@@ -373,7 +376,7 @@ func printString(f string, args []Expr, redirect Token, dest Expr) string {
 	return str
 }
 
-// Printf statement like printf "%3d", 1234.
+// PrintfStmt is a statement like printf "%3d", 1234.
 type PrintfStmt struct {
 	Args     []Expr
 	Redirect Token
@@ -384,7 +387,7 @@ func (s *PrintfStmt) String() string {
 	return printString("printf", s.Args, s.Redirect, s.Dest)
 }
 
-// Expression statement like a bare function call: my_func(x).
+// ExprStmt is statement like a bare function call: my_func(x).
 type ExprStmt struct {
 	Expr Expr
 }
@@ -393,7 +396,7 @@ func (s *ExprStmt) String() string {
 	return s.Expr.String()
 }
 
-// If or if-else statement.
+// IfStmt is an if or if-else statement.
 type IfStmt struct {
 	Cond Expr
 	Body Stmts
@@ -408,7 +411,7 @@ func (s *IfStmt) String() string {
 	return str
 }
 
-// C-like for loop: for (i=0; i<10; i++) print i.
+// ForStmt is a C-like for loop: for (i=0; i<10; i++) print i.
 type ForStmt struct {
 	Pre  Stmt
 	Cond Expr
@@ -432,7 +435,7 @@ func (s *ForStmt) String() string {
 	return "for (" + preStr + ";" + condStr + ";" + postStr + ") {\n" + s.Body.String() + "}"
 }
 
-// For-in loop: for (k in a) print k, a[k].
+// ForInStmt is a for loop like for (k in a) print k, a[k].
 type ForInStmt struct {
 	Var   *VarExpr
 	Array *ArrayExpr
@@ -443,7 +446,7 @@ func (s *ForInStmt) String() string {
 	return "for (" + s.Var.String() + " in " + s.Array.String() + ") {\n" + s.Body.String() + "}"
 }
 
-// While loop.
+// WhileStmt is a while loop.
 type WhileStmt struct {
 	Cond Expr
 	Body Stmts
@@ -453,7 +456,7 @@ func (s *WhileStmt) String() string {
 	return "while (" + trimParens(s.Cond.String()) + ") {\n" + s.Body.String() + "}"
 }
 
-// Do-while loop.
+// DoWhileStmt is a fo-while loop.
 type DoWhileStmt struct {
 	Body Stmts
 	Cond Expr
@@ -463,28 +466,28 @@ func (s *DoWhileStmt) String() string {
 	return "do {\n" + s.Body.String() + "} while (" + trimParens(s.Cond.String()) + ")"
 }
 
-// Break statement.
+// BreakStmt is a break statement.
 type BreakStmt struct{}
 
 func (s *BreakStmt) String() string {
 	return "break"
 }
 
-// Continue statement.
+// ContinueStmt is a continue statement.
 type ContinueStmt struct{}
 
 func (s *ContinueStmt) String() string {
 	return "continue"
 }
 
-// Next statement.
+// NextStmt is a next statement.
 type NextStmt struct{}
 
 func (s *NextStmt) String() string {
 	return "next"
 }
 
-// Exit statement.
+// ExitStmt is an exit statement.
 type ExitStmt struct {
 	Status Expr
 }
@@ -497,7 +500,7 @@ func (s *ExitStmt) String() string {
 	return "exit" + statusStr
 }
 
-// Delete statement like delete a[k].
+// DeleteStmt is a statement like delete a[k].
 type DeleteStmt struct {
 	Array *ArrayExpr
 	Index []Expr
@@ -511,7 +514,7 @@ func (s *DeleteStmt) String() string {
 	return "delete " + s.Array.String() + "[" + strings.Join(indices, ", ") + "]"
 }
 
-// Return statement.
+// ReturnStmt is a return statement.
 type ReturnStmt struct {
 	Value Expr
 }
@@ -524,7 +527,7 @@ func (s *ReturnStmt) String() string {
 	return "return" + valueStr
 }
 
-// Stand-alone block like { print "x" }.
+// BlockStmt is a stand-alone block like { print "x" }.
 type BlockStmt struct {
 	Body Stmts
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -715,7 +715,7 @@ func (p *interp) eval(expr Expr) (value, error) {
 		// Pre-increment, post-increment, pre-decrement, post-decrement
 
 		// First evaluate the expression, but remember array or field
-		// index so we don't evaluate part of the expression twice
+		// index, so we don't evaluate part of the expression twice
 		exprValue, arrayIndex, fieldIndex, err := p.evalForAugAssign(e.Expr)
 		if err != nil {
 			return null(), err
@@ -731,7 +731,7 @@ func (p *interp) eval(expr Expr) (value, error) {
 		}
 		incrValue := num(incr)
 
-		// Finally assign back to expression and return the correct value
+		// Finally, assign back to expression and return the correct value
 		err = p.assignAug(e.Expr, arrayIndex, fieldIndex, incrValue)
 		if err != nil {
 			return null(), err

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -76,7 +76,7 @@ NR==3, NR==5 { print NR }
 	{`BEGIN { printf "%d", 12, 34 }`, "", "12", "", ""},
 	{`BEGIN { printf "%d" }`, "", "", "format error: got 0 args, expected 1", "not enough arg"},
 	// Our %c handling is mostly like awk's, except for multiples
-	// 256, where awk is weird and we're like mawk
+	// 256, where awk is weird, and we're like mawk
 	{`BEGIN { printf "%c", 0 }`, "", "\x00", "", ""},
 	{`BEGIN { printf "%c", 127 }`, "", "\x7f", "", ""},
 	{`BEGIN { printf "%c", 128 }  # !gawk`, "", "\x80", "", ""},

--- a/interp/io.go
+++ b/interp/io.go
@@ -412,7 +412,7 @@ func (p *interp) nextLine() (string, error) {
 }
 
 // Write output string to given writer, producing correct line endings
-// on Windows (CR LF)
+// on Windows (CR LF).
 func writeOutput(w io.Writer, s string) error {
 	if crlfNewline {
 		// First normalize to \n, then convert all newlines to \r\n
@@ -425,7 +425,7 @@ func writeOutput(w io.Writer, s string) error {
 	return err
 }
 
-// Close all streams, commands, etc. (after program execution)
+// Close all streams, commands, and so on (after program execution).
 func (p *interp) closeAll() {
 	if prevInput, ok := p.input.(io.Closer); ok {
 		_ = prevInput.Close()

--- a/interp/io.go
+++ b/interp/io.go
@@ -425,7 +425,7 @@ func writeOutput(w io.Writer, s string) error {
 	return err
 }
 
-// Close all streams, commands, etc (after program execution)
+// Close all streams, commands, etc. (after program execution)
 func (p *interp) closeAll() {
 	if prevInput, ok := p.input.(io.Closer); ok {
 		_ = prevInput.Close()

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -52,7 +52,7 @@ func (l *Lexer) HadSpace() bool {
 }
 
 // Scan scans the next token and returns its position (line/column),
-// token value (one of the uppercased token constants), and the
+// token value (one of the uppercase token constants), and the
 // string value of the token. For most tokens, the token value is
 // empty. For NAME, NUMBER, STRING, and REGEX tokens, it's the
 // token's value. For an ILLEGAL token, it's the error message.

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -12,6 +12,7 @@ const (
 	CONCAT // Not really a token, but used as an operator
 
 	// Symbols
+
 	ADD
 	ADD_ASSIGN
 	AND
@@ -53,6 +54,7 @@ const (
 	SUB_ASSIGN
 
 	// Keywords
+
 	BEGIN
 	BREAK
 	CONTINUE
@@ -73,6 +75,7 @@ const (
 	WHILE
 
 	// Built-in functions
+
 	F_ATAN2
 	F_CLOSE
 	F_COS
@@ -97,6 +100,7 @@ const (
 	F_TOUPPER
 
 	// Literals and names (variables and arrays)
+
 	NAME
 	NUMBER
 	STRING

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,8 +31,8 @@ func (e *ParseError) Error() string {
 	return fmt.Sprintf("parse error at %d:%d: %s", e.Position.Line, e.Position.Column, e.Message)
 }
 
-// ParseConfig lets you specify configuration for the parsing process
-// (for example printing type information for debugging).
+// ParserConfig lets you specify configuration for the parsing
+// process (for example printing type information for debugging).
 type ParserConfig struct {
 	// Enable printing of type information
 	DebugTypes bool
@@ -562,14 +562,14 @@ func (p *parser) _cond(higher func() Expr) Expr {
 	return expr
 }
 
-// Parse an || or expresion:
+// Parse an || or expression:
 //
 //     and [OR NEWLINE* and] [OR NEWLINE* and] ...
 //
 func (p *parser) or() Expr      { return p.binaryLeft(p.and, true, OR) }
 func (p *parser) printOr() Expr { return p.binaryLeft(p.printAnd, true, OR) }
 
-// Parse an && and expresion:
+// Parse an && and expression:
 //
 //     in [AND NEWLINE* in] [AND NEWLINE* in] ...
 //
@@ -769,7 +769,7 @@ func (p *parser) primary() Expr {
 		return &GetlineExpr{nil, varExpr, file}
 	// Below is the parsing of all the builtin function calls. We
 	// could unify these but several of them have special handling
-	// (array/lvalue/regex params, optional arguments, etc), and
+	// (array/lvalue/regex params, optional arguments, etc.), and
 	// doing it this way means we can check more at parse time.
 	case F_SUB, F_GSUB:
 		op := p.tok

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -769,8 +769,8 @@ func (p *parser) primary() Expr {
 		return &GetlineExpr{nil, varExpr, file}
 	// Below is the parsing of all the builtin function calls. We
 	// could unify these but several of them have special handling
-	// (array/lvalue/regex params, optional arguments, etc.), and
-	// doing it this way means we can check more at parse time.
+	// (array/lvalue/regex params, optional arguments, and so on).
+	// Doing it this way means we can check more at parse time.
 	case F_SUB, F_GSUB:
 		op := p.tok
 		p.next()


### PR DESCRIPTION
This addresses some warnings mostly around the convention of the first
word of a godoc being the same as the exported symbol. This also
addresses some typos and some micronits. Any or all of this can be
dismissed if not welcome. I'm just raising this as noticed while
reviewing the code!