### PR TITLE
Fix Unicode separator tests on Windows

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -778,9 +778,6 @@ func (p *interp) setSpecial(index int, v value) error {
 	case ast.V_ORS:
 		p.outputRecordSep = p.toString(v)
 	case ast.V_RS:
-		if p.outputFormat == "ZZZ" {
-			fmt.Printf("TODO FS=%q, RS=%q\n", p.fieldSep, p.toString(v))
-		}
 		p.recordSep = p.toString(v)
 		switch { // compare to interp.newScanner
 		case len(p.recordSep) <= 1:

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -778,6 +778,9 @@ func (p *interp) setSpecial(index int, v value) error {
 	case ast.V_ORS:
 		p.outputRecordSep = p.toString(v)
 	case ast.V_RS:
+		if p.outputFormat == "ZZZ" {
+			fmt.Printf("TODO FS=%q, RS=%q\n", p.fieldSep, p.toString(v))
+		}
 		p.recordSep = p.toString(v)
 		switch { // compare to interp.newScanner
 		case len(p.recordSep) <= 1:

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -311,8 +311,10 @@ BEGIN {
 	// Other FNR behaviour is tested in goawk_test.go
 	{`BEGIN { print "|" FS "|"; FS="," } { print $1, $2 }`, "a b\na,b\nx,,y", "| |\na b \na b\nx \n", "", ""},
 	{`BEGIN { print "|" FS "|"; FS="\\." } { print $1, $2 }`, "a b\na.b\nx..y", "| |\na b \na b\nx \n", "", ""},
+	// ASCII unit and record separator
 	{`BEGIN { FS="\x1f"; RS="\x1e"; OFS="," } { print $1, $2, $3 }`, "id\x1fname\x1fage\x1e1\x1fBob \"Billy\" Smith\x1f42\x1e2\x1fJane\nBrown\x1f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
-	{`BEGIN { FS="␟"; RS="␞"; OFS="," } { print $1, $2, $3 }`, "id␟name␟age␞1␟Bob \"Billy\" Smith␟42␞2␟Jane\nBrown␟37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
+	// Unicode unit and record separator
+	{"BEGIN { FS=\"\u241f\"; RS=\"\u241e\"; OFS=\",\" } { print $1, $2, $3 }", "id\u241fname\u241fage\u241e1\u241fBob \"Billy\" Smith\u241f42\u241e2\u241fJane\nBrown\u241f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
 	{`BEGIN { FS="\\" } { print $1, $2 }`, "a\\b", "a b\n", "", ""},
 	{`{ print NF }`, "\na\nc d\ne f g", "0\n1\n2\n3\n", "", ""},
 	{`BEGIN { NR = 123; print NR }`, "", "123\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -314,7 +314,7 @@ BEGIN {
 	// ASCII unit and record separator
 	{`BEGIN { FS="\x1f"; RS="\x1e"; OFS="," } { print $1, $2, $3 }`, "id\x1fname\x1fage\x1e1\x1fBob \"Billy\" Smith\x1f42\x1e2\x1fJane\nBrown\x1f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
 	// Unicode unit and record separator
-	{"BEGIN { FS=\"\u241f\"; RS=\"\u241e\"; OFS=\",\" } { print $1, $2, $3 }", "id\u241fname\u241fage\u241e1\u241fBob \"Billy\" Smith\u241f42\u241e2\u241fJane\nBrown\u241f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
+	{"BEGIN { OFMT=\"ZZZ\"; FS=\"\u241f\"; RS=\"\u241e\"; OFS=\",\" } { print $1, $2, $3 }", "id\u241fname\u241fage\u241e1\u241fBob \"Billy\" Smith\u241f42\u241e2\u241fJane\nBrown\u241f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
 	{`BEGIN { FS="\\" } { print $1, $2 }`, "a\\b", "a b\n", "", ""},
 	{`{ print NF }`, "\na\nc d\ne f g", "0\n1\n2\n3\n", "", ""},
 	{`BEGIN { NR = 123; print NR }`, "", "123\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -312,9 +312,13 @@ BEGIN {
 	{`BEGIN { print "|" FS "|"; FS="," } { print $1, $2 }`, "a b\na,b\nx,,y", "| |\na b \na b\nx \n", "", ""},
 	{`BEGIN { print "|" FS "|"; FS="\\." } { print $1, $2 }`, "a b\na.b\nx..y", "| |\na b \na b\nx \n", "", ""},
 	// ASCII unit and record separator
-	{`BEGIN { FS="\x1f"; RS="\x1e"; OFS="," } { print $1, $2, $3 }`, "id\x1fname\x1fage\x1e1\x1fBob \"Billy\" Smith\x1f42\x1e2\x1fJane\nBrown\x1f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
-	// Unicode unit and record separator
-	{"BEGIN { OFMT=\"ZZZ\"; FS=\"\u241f\"; RS=\"\u241e\"; OFS=\",\" } { print $1, $2, $3 }", "id\u241fname\u241fage\u241e1\u241fBob \"Billy\" Smith\u241f42\u241e2\u241fJane\nBrown\u241f37", "id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
+	{`BEGIN { FS="\x1f"; RS="\x1e"; OFS="," } { print $1, $2, $3 }`,
+		"id\x1fname\x1fage\x1e1\x1fBob \"Billy\" Smith\x1f42\x1e2\x1fJane\nBrown\x1f37",
+		"id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
+	// Unicode unit and record separator (skip on Windows under gawk due to Unicode command line issues)
+	{`BEGIN { FS="␟"; RS="␞"; OFS=","; print "FS="FS; print "RS="RS; print "-----" } { print $1, $2, $3 }`, // TODO: # !windows-gawk
+		"id␟name␟age␞1␟Bob \"Billy\" Smith␟42␞2␟Jane\nBrown␟37",
+		"id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
 	{`BEGIN { FS="\\" } { print $1, $2 }`, "a\\b", "a b\n", "", ""},
 	{`{ print NF }`, "\na\nc d\ne f g", "0\n1\n2\n3\n", "", ""},
 	{`BEGIN { NR = 123; print NR }`, "", "123\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -316,7 +316,7 @@ BEGIN {
 		"id\x1fname\x1fage\x1e1\x1fBob \"Billy\" Smith\x1f42\x1e2\x1fJane\nBrown\x1f37",
 		"id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
 	// Unicode unit and record separator (skip on Windows under gawk due to Unicode command line issues)
-	{`BEGIN { FS="␟"; RS="␞"; OFS=","; print "FS="FS; print "RS="RS; print "-----" } { print $1, $2, $3 }`, // TODO: # !windows-gawk
+	{`BEGIN { FS="␟"; RS="␞"; OFS="," } { print $1, $2, $3 }  # !windows-gawk`,
 		"id␟name␟age␞1␟Bob \"Billy\" Smith␟42␞2␟Jane\nBrown␟37",
 		"id,name,age\n1,Bob \"Billy\" Smith,42\n2,Jane\nBrown,37\n", "", ""},
 	{`BEGIN { FS="\\" } { print $1, $2 }`, "a\\b", "a b\n", "", ""},


### PR DESCRIPTION
Not sure why the literal Unicode separators didn't work in Go source on Windows, but fix it.