### PR TITLE
Update benchmarks to avoid huge.csv (read benchmark uses write output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ goawk_*.tar.gz
 .idea
 interp/testdata
 scripts/csvbench/bin
-scripts/csvbench/huge.csv
+scripts/csvbench/count.csv

--- a/csv.md
+++ b/csv.md
@@ -277,25 +277,26 @@ NY
 
 The performance of GoAWK's CSV input and output mode is quite good, on a par with using the `encoding/csv` package from Go directly, and much faster than the `csv` module in Python. CSV input speed is significantly slower than `frawk`, though CSV output speed is significantly faster than `frawk`.
 
-Below are the results of some simple read and write [benchmarks](https://github.com/benhoyt/goawk/blob/master/scripts/csvbench) using `goawk` and `frawk` as well as plain Python and Go. The input for the read benchmarks is a large 1.5GB, 749,818-row input file with many columns (286). Times are in seconds, showing the best of three runs on a 64-bit Linux laptop with an SSD drive:
+Below are the results of some simple read and write [benchmarks](https://github.com/benhoyt/goawk/blob/master/scripts/csvbench) using `goawk` and `frawk` as well as plain Python and Go. The output of the write benchmarks is a 1GB, 3.5 million row CSV file with 20 columns (including quoted columns); the input for the read benchmarks uses that same file. Times are in seconds, showing the best of three runs on a 64-bit Linux laptop with an SSD drive:
 
-Test              | goawk | frawk | Python |   Go
------------------ | ----- | ----- | ------ | ----
-Reading 1.5GB CSV |  6.49 |  2.03 |   20.2 | 6.95
-Writing 0.6GB CSV |  3.25 |  7.36 |   10.5 | 2.10
+Test            | goawk | frawk | Python |   Go
+--------------- | ----- | ----- | ------ | ----
+Reading 1GB CSV |  3.18 |  1.01 |   13.4 | 3.22
+Writing 1GB CSV |  5.64 |  13.0 |   17.0 | 3.24
 
 
 ## Future work
 
+* Add a comparison csv [csvkit](https://csvkit.readthedocs.io/en/latest/) tools (of developer experience, not performance), maybe under Examples or in a separate doc. See: https://news.ycombinator.com/item?id=31351116
 * Consider adding a `printrow(a)` or similar function to make it easier to construct CSV rows from scratch.
   - `a` would be an array such as: `a["name"] = "Bob"; a["age"] = 7`
   - keys would be ordered by `OFIELDS` (eg: `OFIELDS[1] = "name"; OFIELDS[2] = "age"`) or by "smart name" if `OFIELDS` not set ("smart name" meaning numeric if `a` keys are numeric, string otherwise)
   - `printrow(a)` could take an optional second `fields` array arg to use that instead of the global `OFIELDS`
 * Consider allowing `-H` to accept an optional list of field names which could be used as headers in the absence of headers in the file itself (either `-H=name,age` or `-i 'csv header=name,age'`).
+* Consider adding TrimLeadingSpace CSV input option. See: https://github.com/benhoyt/goawk/issues/109
 * Consider supporting `@"id" = 42` named field assignment.
 
 
 ## Feedback
 
 Please [open an issue](https://github.com/benhoyt/goawk/issues) if you have bug reports or feature requests for GoAWK's CSV support.
-

--- a/scripts/csvbench/csvbench.sh
+++ b/scripts/csvbench/csvbench.sh
@@ -1,44 +1,48 @@
 #!/bin/sh
 
-echo ===== Reading 1.5GB - goawk
-time goawk -i csv '{ w+=NF } END { print NR, w }' <huge.csv
-time goawk -i csv '{ w+=NF } END { print NR, w }' <huge.csv
-time goawk -i csv '{ w+=NF } END { print NR, w }' <huge.csv
+set -e
 
-echo ===== Reading 1.5GB - frawk
-time frawk -i csv '{ w+=NF } END { print NR, w }' <huge.csv
-time frawk -i csv '{ w+=NF } END { print NR, w }' <huge.csv
-time frawk -i csv '{ w+=NF } END { print NR, w }' <huge.csv
+echo ===== Writing 1GB - goawk
+time goawk -o csv 'BEGIN { for (i=0; i<3514073; i++) print i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field", i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field" }' >/dev/null
+time goawk -o csv 'BEGIN { for (i=0; i<3514073; i++) print i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field", i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field" }' >/dev/null
+time goawk -o csv 'BEGIN { for (i=0; i<3514073; i++) print i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field", i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field" }' >/dev/null
 
-echo ===== Reading 1.5GB - Python
-time python3 count.py <huge.csv
-time python3 count.py <huge.csv
-time python3 count.py <huge.csv
+echo ===== Writing 1GB - frawk
+time frawk -o csv 'BEGIN { for (i=0; i<3514073; i++) print i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field", i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field"; }' >/dev/null
+time frawk -o csv 'BEGIN { for (i=0; i<3514073; i++) print i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field", i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field"; }' >/dev/null
+time frawk -o csv 'BEGIN { for (i=0; i<3514073; i++) print i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field", i, "foo", "bob@example.com", "simple,quoted", "quoted string with \" in it", "0123456789", "9876543210", "The quick brown fox jumps over the lazy dog", "", "final field"; }' >/dev/null
 
-echo ===== Reading 1.5GB - Go
-go build -o bin/count ./count
-time ./bin/count <huge.csv
-time ./bin/count <huge.csv
-time ./bin/count <huge.csv
-
-
-echo ===== Writing 0.6GB - goawk
-time goawk -o csv 'BEGIN { for (i=0; i<10000000; i++) print i, "foo", "bob@example.com", "quoted,string", "final field" }' >/dev/null
-time goawk -o csv 'BEGIN { for (i=0; i<10000000; i++) print i, "foo", "bob@example.com", "quoted,string", "final field" }' >/dev/null
-time goawk -o csv 'BEGIN { for (i=0; i<10000000; i++) print i, "foo", "bob@example.com", "quoted,string", "final field" }' >/dev/null
-
-echo ===== Writing 0.6GB - frawk
-time frawk -o csv 'BEGIN { for (i=0; i<10000000; i++) print i, "foo", "bob@example.com", "quoted,string", "final field"; }' >/dev/null
-time frawk -o csv 'BEGIN { for (i=0; i<10000000; i++) print i, "foo", "bob@example.com", "quoted,string", "final field"; }' >/dev/null
-time frawk -o csv 'BEGIN { for (i=0; i<10000000; i++) print i, "foo", "bob@example.com", "quoted,string", "final field"; }' >/dev/null
-
-echo ===== Writing 0.6GB - Python
+echo ===== Writing 1GB - Python
 time python3 write.py >/dev/null
 time python3 write.py >/dev/null
 time python3 write.py >/dev/null
 
-echo ===== Writing 0.6GB - Go
+echo ===== Writing 1GB - Go
 go build -o bin/write ./write
 time ./bin/write >/dev/null
 time ./bin/write >/dev/null
 time ./bin/write >/dev/null
+
+
+./bin/write >count.csv
+
+echo ===== Reading 1GB - goawk
+time goawk -i csv '{ w+=NF } END { print NR, w }' <count.csv
+time goawk -i csv '{ w+=NF } END { print NR, w }' <count.csv
+time goawk -i csv '{ w+=NF } END { print NR, w }' <count.csv
+
+echo ===== Reading 1GB - frawk
+time frawk -i csv '{ w+=NF } END { print NR, w }' <count.csv
+time frawk -i csv '{ w+=NF } END { print NR, w }' <count.csv
+time frawk -i csv '{ w+=NF } END { print NR, w }' <count.csv
+
+echo ===== Reading 1GB - Python
+time python3 count.py <count.csv
+time python3 count.py <count.csv
+time python3 count.py <count.csv
+
+echo ===== Reading 1GB - Go
+go build -o bin/count ./count
+time ./bin/count <count.csv
+time ./bin/count <count.csv
+time ./bin/count <count.csv

--- a/scripts/csvbench/write.py
+++ b/scripts/csvbench/write.py
@@ -2,5 +2,26 @@ import csv
 import sys
 
 writer = csv.writer(sys.stdout)
-for i in range(10000000):
-	writer.writerow([i, "foo", "bob@example.com", "quoted,string", "final field"])
+for i in range(3514073):  # will create a ~1GB file
+	writer.writerow([
+		i,
+		"foo",
+		"bob@example.com",
+		"simple,quoted",
+		"quoted string with \" in it",
+		"0123456789",
+		"9876543210",
+		"The quick brown fox jumps over the lazy dog",
+		"",
+		"final field",
+		i,
+		"foo",
+		"bob@example.com",
+		"simple,quoted",
+		"quoted string with \" in it",
+		"0123456789",
+		"9876543210",
+		"The quick brown fox jumps over the lazy dog",
+		"",
+		"final field",
+	])

--- a/scripts/csvbench/write/main.go
+++ b/scripts/csvbench/write/main.go
@@ -9,8 +9,29 @@ import (
 
 func main() {
 	writer := csv.NewWriter(os.Stdout)
-	for i := 0; i < 10000000; i++ {
-		err := writer.Write([]string{strconv.Itoa(i), "foo", "bob@example.com", "quoted,string", "final field"})
+	for i := 0; i < 3514073; i++ { // will create a ~1GB file
+		err := writer.Write([]string{
+			strconv.Itoa(i),
+			"foo",
+			"bob@example.com",
+			"simple,quoted",
+			"quoted string with \" in it",
+			"0123456789",
+			"9876543210",
+			"The quick brown fox jumps over the lazy dog",
+			"",
+			"final field",
+			strconv.Itoa(i),
+			"foo",
+			"bob@example.com",
+			"simple,quoted",
+			"quoted string with \" in it",
+			"0123456789",
+			"9876543210",
+			"The quick brown fox jumps over the lazy dog",
+			"",
+			"final field",
+		})
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Previously the read benchmarks (in `scripts/csvbench`) were using a file I had on my machine called `huge.csv`. I found it on the net at some stage but somehow I couldn't find it again. To avoid commit a huge file to source control, and avoid downloading a big file from the net, just have the read benchmark use the output of the write benchmark. Change this to a bit more complex CSV (20 fields, including several quoted fields) and make it 1GB in size.

Relative performance ratios are similar.