### PR TITLE
Wire up stdin in system()

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -562,6 +562,7 @@ BEGIN {
 	{`BEGIN { print system(">&2 echo error") }  # !fuzz`,
 		"", "error\n0\n", "", ""},
 	{`BEGIN { print system("exit 42") }  # !fuzz`, "", "42\n", "", ""},
+	{`BEGIN { system("cat") }`, "foo\nbar", "foo\nbar", "", ""},
 
 	// Test bytes/unicode handling (GoAWK currently has char==byte, unlike Gawk).
 	{`BEGIN { print match("food", "foo"), RSTART, RLENGTH }  !gawk`, "", "1 1 3\n", "", ""},

--- a/interp/vm.go
+++ b/interp/vm.go
@@ -1067,6 +1067,7 @@ func (p *interp) callBuiltin(builtinOp compiler.BuiltinOp) error {
 		}
 		cmdline := p.toString(p.peekTop())
 		cmd := p.execShell(cmdline)
+		cmd.Stdin = p.stdin
 		cmd.Stdout = p.output
 		cmd.Stderr = p.errorOutput
 		_ = p.flushAll() // ensure synchronization


### PR DESCRIPTION
First part of fix for #111. This is why that script was getting `stty: 'standard input': Inappropriate ioctl for device` errors.