### PR TITLE
Ignore UTF-8 BOM at start of CSV files

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1556,6 +1556,9 @@ var csvTests = []csvTest{
 	{`BEGIN { OUTPUTMODE="csv separator=,"; printf "%s", OUTPUTMODE }`, "", "csv", "", nil},
 	{`BEGIN { OUTPUTMODE="csv separator=|"; printf "%s", OUTPUTMODE }`, "", "csv separator=|", "", nil},
 
+	// Ignores UTF-8 byte order mark (BOM) at start of CSV file
+	{`BEGIN { INPUTMODE="csv" } { print $1=="foo" }`, "\ufefffoo,bar\n\ufefffoo,bar", "1\n0\n", "", nil},
+
 	// Error handling when parsing INPUTMODE and OUTPUTMODE
 	{`BEGIN { INPUTMODE="xyz" }`, "", "", `invalid input mode "xyz"`, nil},
 	{`BEGIN { INPUTMODE="csv separator=foo" }`, "", "", `invalid CSV/TSV separator "foo"`, nil},


### PR DESCRIPTION
The UTF-8 BOM was present at the start of some CSV files I found (maybe Excel writes it out?), [for example these ones](https://catalogue.data.govt.nz/dataset/directory-of-educational-institutions/resource/20b7c271-fd5a-4c9e-869b-481a0e2453cd), and it made the first field name `"\ufeff_id"` instead of `"_id"`.