### PR TITLE
More POSIX-accurate handling of cmdline var=value escaping

### DIFF
--- a/goawk.go
+++ b/goawk.go
@@ -35,7 +35,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -276,9 +275,9 @@ func main() {
 		}
 		name, value := v[:equals], v[equals+1:]
 		// Oddly, -v must interpret escapes (issue #129)
-		unquoted, err := strconv.Unquote(`"` + value + `"`)
+		unescaped, err := lexer.Unescape(value)
 		if err == nil {
-			value = unquoted
+			value = unescaped
 		}
 		config.Vars = append(config.Vars, name, value)
 	}

--- a/interp/io.go
+++ b/interp/io.go
@@ -743,9 +743,9 @@ func (p *interp) nextLine() (string, error) {
 					// Yep, set variable to value and keep going
 					name, val := matches[1], matches[2]
 					// Oddly, var=value args must interpret escapes (issue #129)
-					unquoted, err := strconv.Unquote(`"` + val + `"`)
+					unescaped, err := Unescape(val)
 					if err == nil {
-						val = unquoted
+						val = unescaped
 					}
 					err = p.setVarByName(name, val)
 					if err != nil {


### PR DESCRIPTION
Instead of using Go's strconv.Unquote, we should use the same string
parsing we do in the GoAWK lexer. Refactor the string parsing in the
lexer slightly so we can add an Unescape function and use that.