### PR TITLE
Add support for -E argument (like Gawk's -E/--exec)

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -87,6 +87,7 @@ type interp struct {
 	noFileReads   bool
 	shellCommand  []string
 	csvOutput     *bufio.Writer
+	noArgVars     bool
 
 	// Scalars, arrays, and function state
 	globals     []value
@@ -185,7 +186,13 @@ type Config struct {
 	// Input arguments (usually filenames): empty slice means read
 	// only from Stdin, and a filename of "-" means read from Stdin
 	// instead of a real file.
+	//
+	// Arguments of the form "var=value" are treated as variable
+	// assignments.
 	Args []string
+
+	// Set to true to disable "var=value" assignments in Args.
+	NoArgVars bool
 
 	// List of name-value pairs for variables to set before executing
 	// the program (useful for setting FS and other built-in
@@ -432,6 +439,7 @@ func (p *interp) setExecuteConfig(config *Config) error {
 	for i, arg := range config.Args {
 		p.setArrayValue(ast.ScopeGlobal, argvIndex, strconv.Itoa(i+1), numStr(arg))
 	}
+	p.noArgVars = config.NoArgVars
 	p.filenameIndex = 1
 	p.hadFiles = false
 	for i := 0; i < len(config.Vars); i += 2 {

--- a/interp/io.go
+++ b/interp/io.go
@@ -738,7 +738,10 @@ func (p *interp) nextLine() (string, error) {
 				p.filenameIndex++
 
 				// Is it actually a var=value assignment?
-				matches := varRegex.FindStringSubmatch(filename)
+				var matches []string
+				if !p.noArgVars {
+					matches = varRegex.FindStringSubmatch(filename)
+				}
 				if len(matches) >= 3 {
 					// Yep, set variable to value and keep going
 					name, val := matches[1], matches[2]

--- a/testdata/awc.awk
+++ b/testdata/awc.awk
@@ -1,0 +1,17 @@
+BEGIN {
+  for (i = 1; i < ARGC; i++) {
+    if (ARGV[i] == "--") {
+      delete ARGV[i++]
+      break
+    }
+    else if (ARGV[i] !~ /^-./) break
+    else if (ARGV[i] == "-c") c = 1
+    else if (ARGV[i] == "-w") w = 1
+    else if (ARGV[i] == "-l") l = 1
+    else printf "awc: unknown option: %s\n", ARGV[i] >"/dev/stderr"
+    delete ARGV[i]
+  }
+  if (!c && !w && !l) c = w = l = 1
+}
+{ cs += length(); ws += NF; ls++ }
+END { printf "%s%s%s\n", l?ls" ":"", w?ws" ":"", c?cs" ":"" }


### PR DESCRIPTION
It's like -f but stops processing other arguments and disables
foo=bar arguments in the rest of the args. Like Gawk's -E/--exec and
mawk's "-W exec" option.

Also update test runner to run Gawk and GoAWK tests in separate
sub-tests, so one breaking doesn't stop the other from running.

Fixes #139 (thanks @paulapatience)