### PR TITLE
Allow semicolon as terminator for an item

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -808,6 +808,15 @@ BEGIN { foo(5); bar(10) }
 	{`BEGIN { print("x" > "out") }`, "", "1\n", "", ""},
 	{`BEGIN { printf("x" > "out") }`, "", "1", "", ""},
 
+	// Semicolon is allowed as item terminator
+	{"function f(){} ; 0", "", "", "", ""}, // after function
+	{"{}             ; 0", "", "", "", ""}, // after action
+	{"1              ; 0", "", "", "", ""}, // after normal pattern without action
+	// also after the last item
+	{"function f(){} ;  ", "", "", "", ""},
+	{"{}             ;  ", "", "", "", ""},
+	{"1              ;  ", "", "", "", ""},
+
 	// Grammar should allow blocks wherever statements are allowed
 	{`BEGIN { if (1) printf "x"; else printf "y" }`, "", "x", "", ""},
 	{`BEGIN { printf "x"; { printf "y"; printf "z" } }`, "", "xyz", "", ""},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -150,9 +150,30 @@ type parser struct {
 // Parse an entire AWK program.
 func (p *parser) program() *Program {
 	prog := &Program{}
-	p.optionalNewlines()
+
+	// Terminator SEMICOLON|NEWLINE NEWLINE* is required after each item
+	// with two exceptions where it is optional:
+	//
+	// 1. after the last item, or
+	// 2. when the previous item ended with a closing brace.
+	//
+	// NOTE: The second exception does not seem to be correct according to
+	// the Posix grammar definition, but it is the common behaviour for the
+	// major awk implementations.
+	needsTerminator := false
+
 	for p.tok != EOF {
+		if needsTerminator {
+			if !p.matches(NEWLINE, SEMICOLON) {
+				panic(p.errorf("expected ; or newline between items"))
+			}
+			p.next()
+			needsTerminator = false
+		}
+		p.optionalNewlines()
 		switch p.tok {
+		case EOF:
+			break
 		case BEGIN:
 			p.next()
 			prog.Begin = append(prog.Begin, p.stmtsBrace())
@@ -170,7 +191,7 @@ func (p *parser) program() *Program {
 			if !p.matches(LBRACE, EOF) {
 				pattern = append(pattern, p.expr())
 			}
-			if !p.matches(LBRACE, EOF, NEWLINE) {
+			if !p.matches(LBRACE, EOF, NEWLINE, SEMICOLON) {
 				p.commaNewlines()
 				pattern = append(pattern, p.expr())
 			}
@@ -178,11 +199,12 @@ func (p *parser) program() *Program {
 			action := ast.Action{pattern, nil}
 			if p.tok == LBRACE {
 				action.Stmts = p.stmtsBrace()
+			} else {
+				needsTerminator = true
 			}
 			prog.Actions = append(prog.Actions, action)
 			p.inAction = false
 		}
-		p.optionalNewlines()
 	}
 
 	p.resolveUserCalls(prog)


### PR DESCRIPTION
Fixes #145 

Regarding the exception 2. this implementation relies on `p.stmtsBrace()` to consume the possible semicolon after the items ending in closing brace. But if that ever changes, the test cases should fail.