### PR TITLE
Track filenames parsed

### DIFF
--- a/goawk.go
+++ b/goawk.go
@@ -225,7 +225,7 @@ argsLoop:
 		if len(args) < 1 {
 			errorExitf(shortUsage)
 		}
-		err = theParser.ParseFile("<cmdline>", io.NopCloser(strings.NewReader(args[0])))
+		err = theParser.ParseFile("<cmdline>", strings.NewReader(args[0]))
 
 		args = args[1:]
 	}

--- a/goawk.go
+++ b/goawk.go
@@ -264,13 +264,15 @@ argsLoop:
 		prog, err = theParser.Program()
 	}
 	if err != nil {
-		/*if err, ok := err.(*parser.ParseError); ok {
-			name, line := errorFileLine(progFiles, stdinBytes, err.Position.Line)
+		if err, ok := err.(*parser.ParseError); ok {
+			//name, line := errorFileLine(progFiles, stdinBytes, err.Position.Line)
+			name := err.Path
+			line := err.Position.Line
 			fmt.Fprintf(os.Stderr, "%s:%d:%d: %s\n",
 				name, line, err.Position.Column, err.Message)
-			showSourceLine(src, err.Position)
+			showSourceLine(err.Source, err.Position)
 			os.Exit(1)
-		}*/
+		}
 		errorExitf("%s", err)
 	}
 

--- a/goawk.go
+++ b/goawk.go
@@ -212,6 +212,7 @@ argsLoop:
 		for _, progFile := range progFiles {
 			var file *os.File
 			if progFile == "-" {
+				progFile = "<stdin>"
 				file = os.Stdin
 			} else {
 				f, err := os.Open(progFile)
@@ -253,7 +254,7 @@ argsLoop:
 			errorExitf(shortUsage)
 		}
 		//src = []byte(args[0])
-		err = theParser.ParseFile("", io.NopCloser(strings.NewReader(args[0])))
+		err = theParser.ParseFile("<cmdline>", io.NopCloser(strings.NewReader(args[0])))
 
 		args = args[1:]
 	}

--- a/goawk.go
+++ b/goawk.go
@@ -205,18 +205,16 @@ argsLoop:
 	if len(progFiles) > 0 {
 		progFiles = expandWildcardsOnWindows(progFiles)
 		for _, progFile := range progFiles {
-			var file *os.File
 			if progFile == "-" {
-				progFile = "<stdin>"
-				file = os.Stdin
+				err = theParser.ParseFile("<stdin>", os.Stdin)
 			} else {
-				f, err := os.Open(progFile)
-				if err != nil {
-					errorExit(err)
+				file, err1 := os.Open(progFile)
+				if err1 != nil {
+					errorExit(err1)
 				}
-				file = f
+				err = theParser.ParseFile(progFile, file)
+				_ = file.Close()
 			}
-			err = theParser.ParseFile(progFile, file)
 			if err != nil {
 				break
 			}

--- a/goawk_test.go
+++ b/goawk_test.go
@@ -448,7 +448,7 @@ func TestCommandLine(t *testing.T) {
 
 func TestDevStdout(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("/dev/stdout not presnt on Windows")
+		t.Skip("/dev/stdout not present on Windows")
 	}
 	runAWKs(t, []string{`BEGIN { print "1"; print "2">"/dev/stdout" }`}, "", "1\n2\n", "")
 }

--- a/goawk_test.go
+++ b/goawk_test.go
@@ -430,7 +430,7 @@ func TestCommandLine(t *testing.T) {
 		{[]string{"`"}, "", "", "<cmdline>:1:1: unexpected char\n`\n^"},
 		{[]string{"BEGIN {\n\tx*;\n}"}, "", "", "<cmdline>:2:4: expected expression instead of ;\n    x*;\n      ^"},
 		{[]string{"BEGIN {\n\tx*\r\n}"}, "", "", "<cmdline>:2:4: expected expression instead of <newline>\n    x*\n      ^"},
-		{[]string{"-f", "-"}, "\n ++", "", "<stdin>:2:4: expected expression instead of <newline>\n ++\n   ^"},
+		{[]string{"-f", "-"}, "\n ++", "", "<stdin>:2:4: expected expression instead of EOF\n ++\n   ^"},
 		{[]string{"-f", "testdata/parseerror/good.awk", "-f", "testdata/parseerror/bad.awk"},
 			"", "", "testdata/parseerror/bad.awk:2:3: expected expression instead of <newline>\nx*\n  ^"},
 		{[]string{"-f", "testdata/parseerror/bad.awk", "-f", "testdata/parseerror/good.awk"},

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -680,12 +680,17 @@ type PositionError struct {
 	Position Position
 	// Error message.
 	Message string
+	Node    Node
 }
 
 // PosErrorf like fmt.Errorf, but with an explicit position.
 func PosErrorf(pos Position, format string, args ...interface{}) error {
+	return PosNodeErrorf(pos, nil, format, args...)
+}
+
+func PosNodeErrorf(pos Position, node Node, format string, args ...interface{}) error {
 	message := fmt.Sprintf(format, args...)
-	return &PositionError{pos, message}
+	return &PositionError{pos, message, node}
 }
 
 // Error returns a formatted version of the error, including the line

--- a/internal/resolver/resolve.go
+++ b/internal/resolver/resolve.go
@@ -46,13 +46,10 @@ type Config struct {
 func Resolve(prog *ast.Program, config *Config) *ast.ResolvedProgram {
 	r := newResolver(config)
 
-	//fmt.Printf("resolve: %T :: %p\n", prog, prog)
-
 	resolvedProg := &ast.ResolvedProgram{Program: *prog}
 
 	ast.Walk(r, prog)
 
-	//fmt.Printf("after walk: %T :: %p\n", prog, prog)
 	r.resolveUserCalls(prog)
 	r.resolveVars(resolvedProg)
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -153,6 +153,8 @@ func (p *Parser) ParseFile(path string, source io.ReadCloser) (err error) {
 	p.currentFile = path
 	ast.Walk(p, prog)
 
+	// _ = source.Close() TODO
+
 	return err
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -65,7 +65,7 @@ func (c *ParserConfig) toResolverConfig() *resolver.Config {
 // abstract syntax tree or a *ParseError on error. "config" describes
 // the parser configuration (and is allowed to be nil).
 func ParseProgram(src []byte, config *ParserConfig) (prog *Program, err error) {
-	defer recoverParseError(func(posError *ast.PositionError) (path string, src []byte) {
+	defer recoverParseError(func(posError *ast.PositionError) (string, []byte) {
 		return "", src
 	}, func(parseError *ParseError) {
 		err = parseError
@@ -139,8 +139,8 @@ func (p *Parser) ParseFile(path string, source io.ReadCloser) (err error) {
 	if err != nil {
 		return err
 	}
-	defer recoverParseError(func(posError *ast.PositionError) (path string, src []byte) {
-		return "", b
+	defer recoverParseError(func(posError *ast.PositionError) (string, []byte) {
+		return path, b
 	}, func(parseError *ParseError) {
 		err = parseError
 	})
@@ -180,8 +180,9 @@ func (p *Parser) Program() (prog *Program, err error) {
 		if node == nil {
 			panic("posError.Node must be set")
 		}
-		file := p.nodeToFile[node]
-		return file, p.fileToSource[file]
+		path = p.nodeToFile[node]
+		src = p.fileToSource[path]
+		return
 	}, func(parseError *ParseError) {
 		err = parseError
 	})

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -128,20 +128,20 @@ func NewParser(config *ParserConfig) *Parser {
 }
 
 func (p *Parser) ParseFile(path string, source io.Reader) (err error) {
-	scrBytes, err := ioutil.ReadAll(source)
+	srcBytes, err := ioutil.ReadAll(source)
 	if err != nil {
 		return err
 	}
 	defer recoverParseError(func(posError *ast.PositionError) (string, []byte) {
-		return path, scrBytes
+		return path, srcBytes
 	}, func(parseError *ParseError) {
 		err = parseError
 	})
-	prog := parseProgramToAST(scrBytes, p.config)
+	prog := parseProgramToAST(srcBytes, p.config)
 
 	p.programs = append(p.programs, prog)
 
-	p.fileToSource[path] = scrBytes
+	p.fileToSource[path] = srcBytes
 
 	p.currentFile = path
 	ast.Walk(p, prog)


### PR DESCRIPTION
This is the other PR in context of #144.

Here I tried to address the item 1. of your list @benhoyt. 

Eventually I've found semi-elegant solution of how to simplify the position-to-file tracking. 

So the idea is (using `ast.Walk()` functionality that we now have) to keep mapping of Node -> filename for each AST node during parsing individual files. Thus we can resolve the error position back to the file by relying on the node where the error happens. 
This approach also allowed to get rid of the `errorFileLine` function, as expected.

The solution is almost final and test suite is passing. I'm working on final refactorings but would like you to take a look @benhoyt.
