### PR TITLE
Draft version of FileReader

### DIFF
--- a/goawk.go
+++ b/goawk.go
@@ -30,7 +30,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -38,6 +37,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/benhoyt/goawk/internal/parseutil"
 	"github.com/benhoyt/goawk/interp"
 	"github.com/benhoyt/goawk/lexer"
 	"github.com/benhoyt/goawk/parser"
@@ -194,41 +194,37 @@ argsLoop:
 	// Any remaining args are program and input files
 	args := os.Args[i:]
 
-	var src []byte
-	var stdinBytes []byte // used if there's a parse error
+	fileReader := &parseutil.FileReader{}
 	if len(progFiles) > 0 {
 		// Read source: the concatenation of all source files specified
-		buf := &bytes.Buffer{}
 		progFiles = expandWildcardsOnWindows(progFiles)
 		for _, progFile := range progFiles {
 			if progFile == "-" {
-				b, err := ioutil.ReadAll(os.Stdin)
+				err := fileReader.AddFile("<stdin>", os.Stdin)
 				if err != nil {
 					errorExit(err)
 				}
-				stdinBytes = b
-				_, _ = buf.Write(b)
 			} else {
 				f, err := os.Open(progFile)
 				if err != nil {
 					errorExit(err)
 				}
-				_, err = buf.ReadFrom(f)
+				err = fileReader.AddFile(progFile, f)
 				if err != nil {
 					_ = f.Close()
 					errorExit(err)
 				}
 				_ = f.Close()
 			}
-			// Append newline to file in case it doesn't end with one
-			_ = buf.WriteByte('\n')
 		}
-		src = buf.Bytes()
 	} else {
 		if len(args) < 1 {
 			errorExitf(shortUsage)
 		}
-		src = []byte(args[0])
+		err := fileReader.AddFile("<cmdline>", strings.NewReader(args[0]))
+		if err != nil {
+			errorExit(err)
+		}
 		args = args[1:]
 	}
 
@@ -237,13 +233,13 @@ argsLoop:
 		DebugTypes:  debugTypes,
 		DebugWriter: os.Stderr,
 	}
-	prog, err := parser.ParseProgram(src, parserConfig)
+	prog, err := parser.ParseProgram(fileReader.Source(), parserConfig)
 	if err != nil {
 		if err, ok := err.(*parser.ParseError); ok {
-			name, line := errorFileLine(progFiles, stdinBytes, err.Position.Line)
+			name, line := fileReader.FileLine(err.Position.Line)
 			fmt.Fprintf(os.Stderr, "%s:%d:%d: %s\n",
 				name, line, err.Position.Column, err.Message)
-			showSourceLine(src, err.Position)
+			showSourceLine(fileReader.Source(), err.Position)
 			os.Exit(1)
 		}
 		errorExitf("%s", err)
@@ -345,36 +341,6 @@ func showSourceLine(src []byte, pos lexer.Position) {
 	runeColumn := utf8.RuneCountInString(srcLine[:pos.Column-1])
 	fmt.Fprintln(os.Stderr, strings.Replace(srcLine, "\t", "    ", -1))
 	fmt.Fprintln(os.Stderr, strings.Repeat(" ", runeColumn)+strings.Repeat("   ", numTabs)+"^")
-}
-
-// Determine which filename and line number to display for the overall
-// error line number.
-func errorFileLine(progFiles []string, stdinBytes []byte, errorLine int) (string, int) {
-	if len(progFiles) == 0 {
-		return "<cmdline>", errorLine
-	}
-	startLine := 1
-	for _, progFile := range progFiles {
-		var content []byte
-		if progFile == "-" {
-			progFile = "<stdin>"
-			content = stdinBytes
-		} else {
-			b, err := ioutil.ReadFile(progFile)
-			if err != nil {
-				return "<unknown>", errorLine
-			}
-			content = b
-		}
-		content = append(content, '\n')
-
-		numLines := bytes.Count(content, []byte{'\n'})
-		if errorLine >= startLine && errorLine < startLine+numLines {
-			return progFile, errorLine - startLine + 1
-		}
-		startLine += numLines
-	}
-	return "<unknown>", errorLine
 }
 
 func errorExit(err error) {

--- a/internal/parseutil/filereader.go
+++ b/internal/parseutil/filereader.go
@@ -1,0 +1,46 @@
+package parseutil
+
+import (
+	"bytes"
+	"io"
+)
+
+type FileReader struct {
+	files  []file
+	source bytes.Buffer
+}
+
+func (fr *FileReader) AddFile(path string, source io.Reader) error {
+	curLen := len(fr.source.Bytes())
+	_, err := fr.source.ReadFrom(source)
+	if err != nil {
+		return err
+	}
+	if !bytes.HasSuffix(fr.source.Bytes(), []byte("\n")) {
+		fr.source.WriteByte('\n')
+	}
+	content := fr.source.Bytes()[curLen:]
+	lines := bytes.Count(content, []byte("\n"))
+	fr.files = append(fr.files, file{path, lines})
+	return nil
+}
+
+func (fr *FileReader) FileLine(line int) (path string, fileLine int) {
+	startLine := 1
+	for _, f := range fr.files {
+		if line >= startLine && line < startLine+f.lines {
+			return f.path, line - startLine + 1
+		}
+		startLine += f.lines
+	}
+	return "", 0
+}
+
+func (fr *FileReader) Source() []byte {
+	return fr.source.Bytes()
+}
+
+type file struct {
+	path  string
+	lines int
+}


### PR DESCRIPTION
This implements a simple `FileReader` type that tracks files added to it with `AddFile()` and their number of source lines, and then lets you look up which file and file-line number a particular overall line number belongs to with `FileLine()`.

It allows us to do away with `errorFileLine` and look up lines simply, without altering the parser or being invasive in that code.

Just a draft for comparing approaches. Needs comments and tests.