### PR TITLE
Fix tests on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,12 +76,7 @@ jobs:
 
     - name: Build and Test
       run: |
+        set -x
         gawk --version
         gawk 'BEGIN { print 2/3 }'
-        gawk 'BEGIN { print 2/3/4 }'
-        gawk 'BEGIN { print 2/-3 }'
-        gawk 'BEGIN { print -2/3 }'
         gawk 'BEGIN { print "2"/"3" }'
-        gawk 'BEGIN { print 3/.14 }'
-        gawk 'BEGIN { print 2/3, 2/3/4, 2/-3, -2/3, "2"/"3", 3/.14 }'
-        go test -race ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,59 +7,59 @@ on:
     branches: [ master ]
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  # build-linux:
+  #   runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        go: ['1.19', '1.18', '1.17', '1.16', '1.15']
+  #   strategy:
+  #     matrix:
+  #       go: ['1.19', '1.18', '1.17', '1.16', '1.15']
 
-    name: Go ${{ matrix.go }} on Linux
+  #   name: Go ${{ matrix.go }} on Linux
 
-    steps:
-    - uses: actions/checkout@v2
+  #   steps:
+  #   - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
+  #   - name: Set up Go
+  #     uses: actions/setup-go@v2
+  #     with:
+  #       go-version: ${{ matrix.go }}
 
-    - name: Build and Test
-      run: |
-        gawk --version
-        go test -race ./...
+  #   - name: Build and Test
+  #     run: |
+  #       gawk --version
+  #       go test -race ./...
 
-  build-windows:
-    runs-on: windows-latest
+  # build-windows:
+  #   runs-on: windows-latest
 
-    strategy:
-      matrix:
-        go: ['1.19', '1.15']
+  #   strategy:
+  #     matrix:
+  #       go: ['1.19', '1.15']
 
-    name: Go ${{ matrix.go }} on Windows
+  #   name: Go ${{ matrix.go }} on Windows
 
-    steps:
-    - uses: actions/checkout@v2
+  #   steps:
+  #   - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
+  #   - name: Set up Go
+  #     uses: actions/setup-go@v2
+  #     with:
+  #       go-version: ${{ matrix.go }}
 
-    - name: Install Gawk
-      run: choco install gawk
+  #   - name: Install Gawk
+  #     run: choco install gawk
 
-    - name: Build and Test
-      run: |
-        gawk --version
-        go test -race ./...
+  #   - name: Build and Test
+  #     run: |
+  #       gawk --version
+  #       go test -race ./...
 
   build-macos:
     runs-on: macos-latest
 
     strategy:
       matrix:
-        go: ['1.19', '1.15']
+        go: ['1.19'] #, '1.15']
 
     name: Go ${{ matrix.go }} on macOS
 
@@ -77,4 +77,11 @@ jobs:
     - name: Build and Test
       run: |
         gawk --version
+        gawk 'BEGIN { print 2/3 }'
+        gawk 'BEGIN { print 2/3/4 }'
+        gawk 'BEGIN { print 2/-3 }'
+        gawk 'BEGIN { print -2/3 }'
+        gawk 'BEGIN { print "2"/"3" }'
+        gawk 'BEGIN { print 3/.14 }'
+        gawk 'BEGIN { print 2/3, 2/3/4, 2/-3, -2/3, "2"/"3", 3/.14 }'
         go test -race ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,59 +7,59 @@ on:
     branches: [ master ]
 
 jobs:
-  # build-linux:
-  #   runs-on: ubuntu-latest
+  build-linux:
+    runs-on: ubuntu-latest
 
-  #   strategy:
-  #     matrix:
-  #       go: ['1.19', '1.18', '1.17', '1.16', '1.15']
+    strategy:
+      matrix:
+        go: ['1.19', '1.18', '1.17', '1.16', '1.15']
 
-  #   name: Go ${{ matrix.go }} on Linux
+    name: Go ${{ matrix.go }} on Linux
 
-  #   steps:
-  #   - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-  #   - name: Set up Go
-  #     uses: actions/setup-go@v2
-  #     with:
-  #       go-version: ${{ matrix.go }}
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
 
-  #   - name: Build and Test
-  #     run: |
-  #       gawk --version
-  #       go test -race ./...
+    - name: Build and Test
+      run: |
+        gawk --version
+        go test -race ./...
 
-  # build-windows:
-  #   runs-on: windows-latest
+  build-windows:
+    runs-on: windows-latest
 
-  #   strategy:
-  #     matrix:
-  #       go: ['1.19', '1.15']
+    strategy:
+      matrix:
+        go: ['1.19', '1.15']
 
-  #   name: Go ${{ matrix.go }} on Windows
+    name: Go ${{ matrix.go }} on Windows
 
-  #   steps:
-  #   - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-  #   - name: Set up Go
-  #     uses: actions/setup-go@v2
-  #     with:
-  #       go-version: ${{ matrix.go }}
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
 
-  #   - name: Install Gawk
-  #     run: choco install gawk
+    - name: Install Gawk
+      run: choco install gawk
 
-  #   - name: Build and Test
-  #     run: |
-  #       gawk --version
-  #       go test -race ./...
+    - name: Build and Test
+      run: |
+        gawk --version
+        go test -race ./...
 
   build-macos:
     runs-on: macos-latest
 
     strategy:
       matrix:
-        go: ['1.19'] #, '1.15']
+        go: ['1.19', '1.15']
 
     name: Go ${{ matrix.go }} on macOS
 
@@ -76,7 +76,5 @@ jobs:
 
     - name: Build and Test
       run: |
-        set -x
         gawk --version
-        gawk 'BEGIN { print 2/3 }'
-        gawk 'BEGIN { print "2"/"3" }'
+        go test -race ./...

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -247,8 +247,8 @@ BEGIN {
 	{`BEGIN { print 1+2, 1+2+3, 1+-2, -1+2, "1"+"2", 3+.14 }`, "", "3 6 -1 1 3 3.14\n", "", ""},
 	{`BEGIN { print 1-2, 1-2-3, 1-+2, -1-2, "1"-"2", 3-.14 }`, "", "-1 -4 -1 -3 -1 2.86\n", "", ""},
 	{`BEGIN { print 2*3, 2*3*4, 2*-3, -2*3, "2"*"3", 3*.14 }`, "", "6 24 -6 -6 6 0.42\n", "", ""},
-	{`BEGIN { print 2/3, 2/3/4, 2/-3, -2/3, "2"/"3", 3/.14 }`, "", "0.666667 0.166667 -0.666667 -0.666667 0.666667 21.4286\n", "", ""},
-	{`BEGIN { print 2%3, 2%3%4, 2%-3, -2%3, "2"%"3", 3%.14 }`, "", "2 2 2 -2 2 0.06\n", "", ""},
+	{`BEGIN { print 2/3, 2/3/4, 2/-3, -2/3, "2"/"3", 3/.14 }  # !darwin-gawk`, "", "0.666667 0.166667 -0.666667 -0.666667 0.666667 21.4286\n", "", ""},
+	{`BEGIN { print 2%3, 2%3%4, 2%-3, -2%3, "2"%"3", 3%.14 }  # !darwin-gawk`, "", "2 2 2 -2 2 0.06\n", "", ""},
 	{`BEGIN { print 2^3, 2^3^3, 2^-3, -2^3, "2"^"3", 3^.14 }`, "", "8 134217728 0.125 -8 8 1.16626\n", "", ""},
 	{`BEGIN { print 2**3, 2**3**3, 2**-3, -2**3, "2"**"3", 3**.14 }  # !posix`, "", "8 134217728 0.125 -8 8 1.16626\n", "", ""},
 	{`BEGIN { print 1 2, "x" "yz", 1+2 3+4 }`, "", "12 xyz 37\n", "", ""},
@@ -262,7 +262,7 @@ BEGIN {
 
 	// Number, string, and regex expressions
 	{`BEGIN { print 1, 1., .1, 1e0, -1, 1e }`, "", "1 1 0.1 1 -1 1\n", "", ""},
-	{`BEGIN { print '\"' '\'' 'xy' "z" "'" '\"' }`, "", "\"'xyz'\"\n", "", "syntax error"}, // Check support for single-quoted strings
+	{`BEGIN { print '\"' '\'' 'xy' "z" "'" '\"' }`, "", "\"'xyz'\"\n", "", "invalid char"}, // Check support for single-quoted strings
 	{`BEGIN { print "0\n1\t2\r3\a4\b5\f6\v7\x408\xf" }  # !posix`, "", "0\n1\t2\r3\a4\b5\f6\v7@8\x0f\n", "", ""},
 	{`{ print /foo/ }`, "food\nfoo\nxfooz\nbar\n", "1\n1\n1\n0\n", "", ""},
 	{`/[a-/`, "foo", "", "parse error at 1:1: error parsing regexp: missing closing ]: `[a-`", "terminated"},
@@ -839,7 +839,7 @@ BEGIN { foo(5); bar(10) }
 	{"/foo\n", "", "", "parse error at 1:5: can't have newline in regex", "unterminated regexp"},
 	{`BEGIN { print "\x" }  # !gawk`, "", "", "parse error at 1:18: 1 or 2 hex digits expected", ""},
 	{`BEGIN { print 1&*2 }`, "", "", "parse error at 1:17: unexpected char after '&'", "syntax"},
-	{"BEGIN { ` }", "", "", "parse error at 1:9: unexpected char", "syntax"},
+	{"BEGIN { ` }", "", "", "parse error at 1:9: unexpected char", "invalid char"},
 
 	// Hex floating point and other number conversions
 	{`{ print $1+0 }  # +posix`, `


### PR DESCRIPTION
They're failing in weird ways, for example:

```
GNU Awk 5.2.0, API 3.2, PMA Avon 7, (GNU MPFR 4.1.0-p13, GNU MP 6.2.1)
Copyright (C) 1989, 1991-2022 Free Software Foundation.

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 3 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program. If not, see [http://www.gnu.org/licenses/.](http://www.gnu.org/licenses/)
ok  	github.com/benhoyt/goawk	34.037s
ok  	github.com/benhoyt/goawk/internal/ast	0.168s
ok  	github.com/benhoyt/goawk/internal/compiler	0.277s
ok  	github.com/benhoyt/goawk/internal/cover	0.177s
ok  	github.com/benhoyt/goawk/internal/parseutil	0.186s
ok  	github.com/benhoyt/goawk/internal/resolver	0.149s
--- FAIL: TestInterp (12.04s)
    --- FAIL: TestInterp/awk_BEGIN_{_print_2/3,_2/3/4,_2/-3,_-2/3,_"2"/"3",_3/.14_} (0.01s)
        interp_test.go:972: error running gawk: exit status 1:
            gawk: cmd. line:1: error: division by zero attempted
    --- FAIL: TestInterp/awkposix_BEGIN_{_print_2/3,_2/3/4,_2/-3,_-2/3,_"2"/"3",_3/.14_} (0.01s)
        interp_test.go:972: error running gawk: exit status 1:
            gawk: cmd. line:1: error: division by zero attempted
    --- FAIL: TestInterp/awk_BEGIN_{_print_2%3,_2%3%4,_2%-3,_-2%3,_"2"%"3",_3%.14_} (0.01s)
        interp_test.go:972: error running gawk: exit status 1:
            gawk: cmd. line:1: error: division by zero attempted in `%'
    --- FAIL: TestInterp/awkposix_BEGIN_{_print_2%3,_2%3%4,_2%-3,_-2%3,_"2"%"3",_3%.14_} (0.01s)
        interp_test.go:972: error running gawk: exit status 1:
            gawk: cmd. line:1: error: division by zero attempted in `%'
    --- FAIL: TestInterp/awk_BEGIN_{_print_'\"'_'\''_'xy'_"z"_"'"_'\"'_} (0.01s)
        interp_test.go:970: expected error "syntax error", got:
            gawk: cmd. line:1: BEGIN { print '\"' '\'' 'xy' "z" "'" '\"' }
            gawk: cmd. line:1:               ^ invalid char ''' in expression
    --- FAIL: TestInterp/awkposix_BEGIN_{_print_'\"'_'\''_'xy'_"z"_"'"_'\"'_} (0.01s)
        interp_test.go:970: expected error "syntax error", got:
            gawk: cmd. line:1: BEGIN { print '\"' '\'' 'xy' "z" "'" '\"' }
            gawk: cmd. line:1:               ^ invalid char ''' in expression
    --- FAIL: TestInterp/awk_BEGIN_{_`_} (0.01s)
        interp_test.go:970: expected error "syntax", got:
            gawk: cmd. line:1: BEGIN { ` }
            gawk: cmd. line:1:         ^ invalid char '`' in expression
    --- FAIL: TestInterp/awkposix_BEGIN_{_`_} (0.01s)
        interp_test.go:970: expected error "syntax", got:
            gawk: cmd. line:1: BEGIN { ` }
            gawk: cmd. line:1:         ^ invalid char '`' in expression
FAIL
FAIL	github.com/benhoyt/goawk/interp	12.573s
ok  	github.com/benhoyt/goawk/lexer	0.308s
ok  	github.com/benhoyt/goawk/parser	0.941s
?   	github.com/benhoyt/goawk/scripts/csvbench/count	[no test files]
?   	github.com/benhoyt/goawk/scripts/csvbench/write	[no test files]
FAIL
```