### PR TITLE
Allow parsing of "cond && var=value" and similar expressions

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -470,6 +470,10 @@ BEGIN {
 	{`function inca(a, k, n) { a[k] += n }  BEGIN { b["x"]=7; inca(b, "x", 2); print b["x"] }`, "", "9\n", "", ""},
 	{`BEGIN { NF += 3; print NF }`, "", "3\n", "", ""},
 	{`BEGIN { x=1; x += x+=3; print x }`, "", "8\n", "", ""},
+	{`BEGIN { if (1&&x=2) print "t", x }`, "", "t 2\n", "", ""},
+	{`BEGIN { if (0||x+=2) print "t", x }`, "", "t 2\n", "", ""},
+	{`BEGIN { print(1&&x=2, 1||x=2, 1~x=2, 1!~x=2, 1==x=2, 1!=x=2, 1<x=2, 1<=x=2, 1>x=2, 1>=x=2); print x }`,
+		"", "1 1 0 1 0 1 1 1 0 0\n2\n", "", ""},
 
 	// Incr/decr expressions
 	{`BEGIN { print x++; print x }`, "", "0\n1\n", "", ""},
@@ -843,6 +847,8 @@ BEGIN { foo(5); bar(10) }
 	{`BEGIN { print 1&*2 }`, "", "", "parse error at 1:17: unexpected char after '&'", "syntax"},
 	{"BEGIN { ` }", "", "", "parse error at 1:9: unexpected char", "invalid char"},
 	{"BEGIN { ++3 }", "", "", "parse error at 1:11: expected lvalue after ++", "syntax"},
+	{"BEGIN { rand() = 1 }", "", "", "parse error at 1:9: expected lvalue before =", "syntax"},
+	{"BEGIN { 1 && rand()=1 }", "", "", "parse error at 1:9: expected lvalue before =", "syntax"},
 
 	// Hex floating point and other number conversions
 	{`{ print $1+0 }  # +posix`, `

--- a/testdata/gawk/badassign1.ok
+++ b/testdata/gawk/badassign1.ok
@@ -1,1 +1,1 @@
-parse error at 1:14: expected ; or newline between statements
+parse error at 1:9: expected lvalue before =


### PR DESCRIPTION
Expressions like "1 && x=1" aren't really valid (IMO), because assignments are lower-precedence than binary operators, but onetrueawk, Gawk, and mawk all support this for logical, match and comparison operators.

The other awks support this by using a yacc grammar which supports backtracking, and as [Vitus13 said on reddit](https://www.reddit.com/r/ProgrammingLanguages/comments/10zfg1z/why_does_awk_parse_1x1_as_1x1_not_1x1_when_is/): "If there are two syntactically valid parsings and one is a semantic error, the error handling may resolve the ambiguity towards the valid parsing. In this case, you can only assign to L values, so trying to assign to (1&&x) doesn't make any sense."

In GoAWK, this requires a form of backtracking (I call it "partial backtracking" because it's not actually backing up the lexer). It works by parsing as (1&&x)=1 according to the operator precedence, then determining that you're trying to assign something that isn't an lvalue, then confirming that 1&&x is a binary expression, that the "x" part is an lvalue, and that the operator (&& in this case) is one that the other awks handle similarly for this case.

Also make the error message a bit clearer when you don't have an lvalue on the left hand side of an assignment, like "rand() = 1".

Fixes #166