### PR TITLE
When running "gawk --posix", ensure we're using UTF-8

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -489,7 +489,9 @@ func runAWKs(t *testing.T, testArgs []string, testStdin, testOutput, testError s
 		}
 		args = append(args, testArgs...)
 		cmd := exec.Command(awkExe, testArgs...)
-		//TODO cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+		if runtime.GOOS != "windows" {
+			cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+		}
 		if testStdin != "" {
 			cmd.Stdin = strings.NewReader(testStdin)
 		}

--- a/goawk_test.go
+++ b/goawk_test.go
@@ -489,6 +489,7 @@ func runAWKs(t *testing.T, testArgs []string, testStdin, testOutput, testError s
 		}
 		args = append(args, testArgs...)
 		cmd := exec.Command(awkExe, testArgs...)
+		cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
 		if testStdin != "" {
 			cmd.Stdin = strings.NewReader(testStdin)
 		}

--- a/goawk_test.go
+++ b/goawk_test.go
@@ -489,7 +489,7 @@ func runAWKs(t *testing.T, testArgs []string, testStdin, testOutput, testError s
 		}
 		args = append(args, testArgs...)
 		cmd := exec.Command(awkExe, testArgs...)
-		cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+		//TODO cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
 		if testStdin != "" {
 			cmd.Stdin = strings.NewReader(testStdin)
 		}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -973,6 +973,7 @@ func TestInterp(t *testing.T) {
 				}
 				args = append(args, test.src, "-")
 				cmd := exec.Command(awkExe, args...)
+				cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
 				if test.in != "" {
 					cmd.Stdin = strings.NewReader(test.in)
 				}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -973,7 +973,9 @@ func TestInterp(t *testing.T) {
 				}
 				args = append(args, test.src, "-")
 				cmd := exec.Command(awkExe, args...)
-				//TODO cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+				if runtime.GOOS != "windows" {
+					cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+				}
 				if test.in != "" {
 					cmd.Stdin = strings.NewReader(test.in)
 				}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -973,7 +973,7 @@ func TestInterp(t *testing.T) {
 				}
 				args = append(args, test.src, "-")
 				cmd := exec.Command(awkExe, args...)
-				cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+				//TODO cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
 				if test.in != "" {
 					cmd.Stdin = strings.NewReader(test.in)
 				}


### PR DESCRIPTION
This avoids the following test failure when LC_ALL=C:

```
$ go test ./interp
--- FAIL: TestInterp (1.80s)
    --- FAIL: TestInterp/awkposix_BEGIN_{_RS="ö"_}__{_print_}__#_!windows-gawk (0.00s)
        interp_test.go:983: expected/got:
            "1\ntwo\nthree\n"
            "1\n\xb6two\n\xb6three\n"
FAIL
FAIL	github.com/benhoyt/goawk/interp	1.874s
FAIL
```

Also make the same change in goawk_test.go to avoid issues in future (though that doesn't fail right now).

Thanks to Jan Mercl for the bug report.