### PR TITLE
Refactor and simplify resolver to use two passes

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -622,7 +622,25 @@ func TestGoAWKSpecificOptions(t *testing.T) {
 		{[]string{"-oxyz", `{}`}, "", "", "invalid output mode \"xyz\"\n"},
 		{[]string{"-H", `{}`}, "", "", "-H only allowed together with -i\n"},
 
-		// Debug options (don't test -dt as its output is not stable)
+		// Debug options
+		{[]string{"-dt", `
+BEGIN { x=42; a[1]=x; print f(a, 1) }
+function f(b, y, z) { return b[y+z] }
+function hi(x) { print "hi " x }
+`}, "", `
+globals
+  ARGV: array 0
+  ENVIRON: array 1
+  FIELDS: array 2
+  a: array 3
+  x: scalar 0
+function f(b, y, z)  # index 0
+  b: array 0
+  y: scalar 0
+  z: scalar 1
+function hi(x)  # index 1
+  x: scalar 0
+`[1:], ""},
 		{[]string{"-d", `$1 { print 1+1 }`}, "", `
 $1 {
     print 1 + 1

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -722,7 +722,6 @@ type DeleteStmt struct {
 
 func (s *DeleteStmt) String() string {
 	if len(s.Index) == 0 {
-		// TODO: add test for this missing case
 		return "delete " + s.Array
 	}
 	indices := make([]string, len(s.Index))

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -581,7 +581,7 @@ type IfStmt struct {
 }
 
 func (s *IfStmt) String() string {
-	str := "if (" + trimParens(s.Cond.String()) + ") {\n" + s.Body.String() + "}"
+	str := "if (" + s.Cond.String() + ") {\n" + s.Body.String() + "}"
 	if len(s.Else) > 0 {
 		str += " else {\n" + s.Else.String() + "}"
 	}
@@ -606,7 +606,7 @@ func (s *ForStmt) String() string {
 	}
 	condStr := ""
 	if s.Cond != nil {
-		condStr = " " + trimParens(s.Cond.String())
+		condStr = " " + s.Cond.String()
 	}
 	postStr := ""
 	if s.Post != nil {
@@ -641,7 +641,7 @@ type WhileStmt struct {
 }
 
 func (s *WhileStmt) String() string {
-	return "while (" + trimParens(s.Cond.String()) + ") {\n" + s.Body.String() + "}"
+	return "while (" + s.Cond.String() + ") {\n" + s.Body.String() + "}"
 }
 
 // DoWhileStmt is a do-while loop.
@@ -653,7 +653,7 @@ type DoWhileStmt struct {
 }
 
 func (s *DoWhileStmt) String() string {
-	return "do {\n" + s.Body.String() + "} while (" + trimParens(s.Cond.String()) + ")"
+	return "do {\n" + s.Body.String() + "} while (" + s.Cond.String() + ")"
 }
 
 // BreakStmt is a break statement.
@@ -768,14 +768,6 @@ type Function struct {
 func (f *Function) String() string {
 	return "function " + f.Name + "(" + strings.Join(f.Params, ", ") + ") {\n" +
 		f.Body.String() + "}"
-}
-
-// TODO: do we still need this with how we doing parenthesize() now?
-func trimParens(s string) string {
-	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
-		s = s[1 : len(s)-1]
-	}
-	return s
 }
 
 // PositionError represents an error bound to specific position in source.

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -2,7 +2,7 @@ package ast
 
 import "fmt"
 
-// A Visitor's Visit method is invoked for each node encountered by Walk.
+// Visitor has a Visit method which is invoked for each node encountered by Walk.
 // If the result visitor w is not nil, Walk visits each of the children
 // of node with the visitor w, followed by a call of w.Visit(nil).
 type Visitor interface {
@@ -55,10 +55,8 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Left)
 		Walk(v, n.Right)
 
-	case *ArrayExpr: // leaf
 	case *InExpr:
 		WalkExprList(v, n.Index)
-		Walk(v, n.Array)
 
 	case *CondExpr:
 		Walk(v, n.Cond)
@@ -70,7 +68,6 @@ func Walk(v Visitor, node Node) {
 	case *RegExpr: // leaf
 	case *VarExpr: // leaf
 	case *IndexExpr:
-		Walk(v, n.Array)
 		WalkExprList(v, n.Index)
 
 	case *AssignExpr:
@@ -125,8 +122,6 @@ func Walk(v Visitor, node Node) {
 		WalkStmtList(v, n.Body)
 
 	case *ForInStmt:
-		Walk(v, n.Var)
-		Walk(v, n.Array)
 		WalkStmtList(v, n.Body)
 
 	case *WhileStmt:
@@ -145,7 +140,6 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Status)
 
 	case *DeleteStmt:
-		Walk(v, n.Array)
 		WalkExprList(v, n.Index)
 
 	case *ReturnStmt:

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -242,7 +242,7 @@ func (cover *Cover) trackStatement(stmts []ast.Stmt) ast.Stmt {
 		numStmts: len(stmts),
 	})
 	left := &ast.IndexExpr{
-		Array: ast.ArrayRef(ArrayName, lexer.Position{}),
+		Array: ArrayName,
 		Index: []ast.Expr{&ast.NumExpr{Value: float64(len(cover.trackedBlocks))}},
 	}
 	if cover.mode == ModeCount {

--- a/internal/resolver/resolve.go
+++ b/internal/resolver/resolve.go
@@ -14,8 +14,6 @@ import (
 	"github.com/benhoyt/goawk/lexer"
 )
 
-// TODO: bug: goawk 'BEGIN { a["x"]=1; for (NR in a) print NR, a[NR] }'
-
 // ResolvedProgram is a parsed AWK program plus variable scope and type data
 // prepared by the resolver that is needed for subsequent interpretation.
 type ResolvedProgram struct {

--- a/internal/resolver/resolve.go
+++ b/internal/resolver/resolve.go
@@ -5,7 +5,6 @@ package resolver
 import (
 	"fmt"
 	"io"
-	"math"
 	"reflect"
 	"sort"
 	"strings"
@@ -425,7 +424,7 @@ func (v *mainVisitor) Visit(node ast.Node) ast.Visitor {
 			typ := reflect.TypeOf(v.nativeFuncs[n.Name])
 			numParams = typ.NumIn()
 			if typ.IsVariadic() {
-				numParams = math.MaxInt
+				numParams = 1000000000 // bigger than any reasonable len(n.Args) value!
 			}
 		}
 		if len(n.Args) > numParams {

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/benhoyt/goawk/internal/ast"
+	"github.com/benhoyt/goawk/internal/resolver"
 	. "github.com/benhoyt/goawk/lexer"
 )
 
@@ -242,7 +242,7 @@ func validNativeType(typ reflect.Type) bool {
 }
 
 // Guts of the split() function
-func (p *interp) split(s string, scope ast.VarScope, index int, fs string) (int, error) {
+func (p *interp) split(s string, scope resolver.Scope, index int, fs string) (int, error) {
 	var parts []string
 	if fs == " " {
 		parts = strings.Fields(s)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -711,12 +711,12 @@ BEGIN { a[1]=2; f1(a); print f2(a, 1) }
 	{`BEGIN { a[x]; a=42 }`, "", "", `parse error at 1:15: can't use array "a" as scalar`, "array"},
 	{`BEGIN { s=42; s[x] }`, "", "", `parse error at 1:15: can't use scalar "s" as array`, "array"},
 	{`function get(a, k) { return a[k] }  BEGIN { a = 42; print get(a, 1); }  # !awk - doesn't error in awk`,
-		"", "", `parse error at 1:59: can't pass scalar "a" as array param`, "attempt to use scalar parameter `a' as an array"},
+		"", "", `parse error at 1:63: can't pass scalar "a" as array param`, "attempt to use scalar parameter `a' as an array"},
 	{`function get(a, k) { return a+k } BEGIN { a[42]; print get(a, 1); }`,
-		"", "", `parse error at 1:56: can't pass array "a" as scalar param`, "array"},
+		"", "", `parse error at 1:60: can't pass array "a" as scalar param`, "array"},
 	{`{ f(z) }  function f(x) { print NR }`, "abc", "1\n", "", ""},
 	{`function f() { f() }  BEGIN { f() }  # !awk !gawk`, "", "", `calling "f" exceeded maximum call depth of 1000`, ""},
-	{`function f(x) { 0 in x }  BEGIN { f(FS) }  # !awk`, "", "", `parse error at 1:35: can't pass scalar "FS" as array param`, "attempt to use scalar parameter `x' as an array"},
+	{`function f(x) { 0 in x }  BEGIN { f(FS) }  # !awk`, "", "", `parse error at 1:37: can't pass scalar "FS" as array param`, "attempt to use scalar parameter `x' as an array"},
 	{`
 function foo(x) { print "foo", x }
 function bar(foo) { print "bar", foo }
@@ -729,8 +729,10 @@ function bar(foo) { print "bar", foo }
 BEGIN { foo(5); bar(10) }
 `, "", "", `parse error at 2:14: can't use function name as parameter name`, "function name"},
 	{`function foo() { print foo }  BEGIN { foo() }`,
-		"", "", `parse error at 1:1: global var "foo" can't also be a function`, "function"},
+		"", "", `parse error at 1:24: global var "foo" can't also be a function`, "function"},
 	{`function f(x) { print x, x(); }  BEGIN { f() }`, "", "", `parse error at 1:26: can't call local variable "x" as function`, "function"},
+	{`function f(x) { print x } BEGIN { print f(1, 2) }  # !gawk`, // only a warning in Gawk
+		"", "", `parse error at 1:41: "f" called with more arguments than declared`, ""},
 
 	// Redirected I/O
 	{`BEGIN { getline x; print x }`, "foo", "foo\n", "", ""},
@@ -1283,17 +1285,22 @@ BEGIN { x=4; y=5; print foo(x), bar(y) }
 				"foo": func(n int) int { return n * n },
 			}},
 		{`BEGIN { a["x"]=1; print foo(a) }`, "", "",
-			`parse error at 1:25: can't pass array "a" to native function`,
+			`parse error at 1:29: can't use array "a" as scalar`,
+			map[string]interface{}{
+				"foo": func(n int) int { return n * n },
+			}},
+		{`BEGIN { print foo(a); a["x"]=1 }`, "", "",
+			`parse error at 1:23: can't use scalar "a" as array`,
 			map[string]interface{}{
 				"foo": func(n int) int { return n * n },
 			}},
 		{`BEGIN { x["x"]=1; print f(x) }  function f(a) { return foo(a) }`, "", "",
-			`parse error at 1:56: can't pass array "a" to native function`,
+			`parse error at 1:27: can't pass array "x" as scalar param`,
 			map[string]interface{}{
 				"foo": func(n int) int { return n * n },
 			}},
 		{`function f(a) { return foo(a) }  BEGIN { x["x"]=1; print f(x) }`, "", "",
-			`parse error at 1:24: can't pass array "a" to native function`,
+			`parse error at 1:60: can't pass array "x" as scalar param`,
 			map[string]interface{}{
 				"foo": func(n int) int { return n * n },
 			}},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -137,6 +137,8 @@ NR==3, NR==5 { print NR }
 	{`BEGIN { a[1]=1; a[2]=1; a[3]=1; for (k in a) { if (k==2) continue; s++ } print s }`, "", "2\n", "", ""},
 	{`function alen(a, k, n) { n=0; for (k in a) n++; return n }  BEGIN { a[1]=1; a[2]=1; print alen(a) }`, "", "2\n", "", ""},
 	{`BEGIN { a["x"]=1; for (SUBSEP in a) print SUBSEP, a[SUBSEP] }`, "", "x 1\n", "", ""},
+	// TODO: this doesn't work in GoAWK yet
+	// {`BEGIN { a["x"]=1; for (NR in a) print NR, a[NR] }`, "", "x 1\n", "", ""},
 	{`BEGIN { while (i<3) { i++; s++; break } print s }`, "", "1\n", "", ""},
 	{`BEGIN { while (i<3) { i++; if (i==2) continue; s++ } print s }`, "", "2\n", "", ""},
 	{`BEGIN { do { i++; s++; break } while (i<3); print s }`, "", "1\n", "", ""},

--- a/interp/io.go
+++ b/interp/io.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/benhoyt/goawk/internal/ast"
+	"github.com/benhoyt/goawk/internal/resolver"
 	. "github.com/benhoyt/goawk/lexer"
 )
 
@@ -294,7 +294,7 @@ func (p *interp) setFieldNames(names []string) {
 	p.fieldIndexes = nil // clear name-to-index cache
 
 	// Populate FIELDS array (mapping of field indexes to field names).
-	fieldsArray := p.array(ast.ScopeGlobal, p.program.Arrays["FIELDS"])
+	fieldsArray := p.array(resolver.Global, p.arrayIndexes["FIELDS"])
 	for k := range fieldsArray {
 		delete(fieldsArray, k)
 	}
@@ -732,8 +732,8 @@ func (p *interp) nextLine() (string, error) {
 				// getArrayValue() here as it would set the value if
 				// not present
 				index := strconv.Itoa(p.filenameIndex)
-				argvIndex := p.program.Arrays["ARGV"]
-				argvArray := p.array(ast.ScopeGlobal, argvIndex)
+				argvIndex := p.arrayIndexes["ARGV"]
+				argvArray := p.array(resolver.Global, argvIndex)
 				filename := p.toString(argvArray[index])
 				p.filenameIndex++
 

--- a/interp/newexecute.go
+++ b/interp/newexecute.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/benhoyt/goawk/internal/ast"
+	"github.com/benhoyt/goawk/internal/resolver"
 	"github.com/benhoyt/goawk/parser"
 )
 
@@ -65,11 +65,11 @@ func (p *Interpreter) Execute(config *Config) (int, error) {
 // numbers are included as type float64, strings (including "numeric strings")
 // are included as type string. If the named array does not exist, return nil.
 func (p *Interpreter) Array(name string) map[string]interface{} {
-	index, exists := p.interp.program.Arrays[name]
+	index, exists := p.interp.arrayIndexes[name]
 	if !exists {
 		return nil
 	}
-	array := p.interp.array(ast.ScopeGlobal, index)
+	array := p.interp.array(resolver.Global, index)
 	result := make(map[string]interface{}, len(array))
 	for k, v := range array {
 		switch v.typ {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -39,6 +39,7 @@ $0 {
     print "x" >"file"
     print "x" >>"append"
     print "y" |"prog"
+    delete a
     delete a[k]
     if (c) {
         get(a, k)

--- a/testdata/gawk/arrayparm.ok
+++ b/testdata/gawk/arrayparm.ok
@@ -1,1 +1,1 @@
-parse error at 10:5: can't pass array "foo" as scalar param
+parse error at 10:10: can't pass array "foo" as scalar param

--- a/testdata/gawk/arryref3.ok
+++ b/testdata/gawk/arryref3.ok
@@ -1,1 +1,1 @@
-parse error at 12:2: can't pass array "b" as scalar param
+parse error at 12:6: can't pass array "b" as scalar param

--- a/testdata/gawk/arryref4.ok
+++ b/testdata/gawk/arryref4.ok
@@ -1,1 +1,1 @@
-parse error at 2:2: can't pass scalar "a" as array param
+parse error at 2:6: can't pass scalar "a" as array param

--- a/testdata/gawk/arryref5.ok
+++ b/testdata/gawk/arryref5.ok
@@ -1,1 +1,1 @@
-parse error at 2:2: can't pass scalar "a" as array param
+parse error at 2:6: can't pass scalar "a" as array param

--- a/testdata/gawk/aryprm4.ok
+++ b/testdata/gawk/aryprm4.ok
@@ -1,1 +1,1 @@
-parse error at 5:2: can't pass array "a" as scalar param
+parse error at 6:2: can't use scalar "a" as array

--- a/testdata/gawk/aryprm6.ok
+++ b/testdata/gawk/aryprm6.ok
@@ -1,1 +1,1 @@
-parse error at 6:2: can't pass scalar "a" as array param
+parse error at 6:4: can't pass scalar "a" as array param

--- a/testdata/gawk/aryprm7.ok
+++ b/testdata/gawk/aryprm7.ok
@@ -1,1 +1,1 @@
-parse error at 5:2: can't pass array "a" as scalar param
+parse error at 5:7: can't pass scalar "a" as array param

--- a/testdata/gawk/delfunc.ok
+++ b/testdata/gawk/delfunc.ok
@@ -1,1 +1,1 @@
-parse error at 1:1: global var "f" can't also be a function
+parse error at 4:9: global var "f" can't also be a function

--- a/testdata/gawk/fnamedat.ok
+++ b/testdata/gawk/fnamedat.ok
@@ -1,1 +1,1 @@
-parse error at 1:1: global var "foo" can't also be a function
+parse error at 1:24: global var "foo" can't also be a function

--- a/testdata/gawk/fnarray.ok
+++ b/testdata/gawk/fnarray.ok
@@ -1,1 +1,1 @@
-parse error at 1:1: global var "foo" can't also be a function
+parse error at 5:9: global var "foo" can't also be a function

--- a/testdata/gawk/fnarray2.ok
+++ b/testdata/gawk/fnarray2.ok
@@ -1,1 +1,1 @@
-parse error at 1:1: global var "pile" can't also be a function
+parse error at 3:8: global var "pile" can't also be a function

--- a/testdata/gawk/fnaryscl.ok
+++ b/testdata/gawk/fnaryscl.ok
@@ -1,1 +1,1 @@
-parse error at 3:2: can't pass array "foo" as scalar param
+parse error at 3:5: can't pass array "foo" as scalar param

--- a/testdata/gawk/fnasgnm.ok
+++ b/testdata/gawk/fnasgnm.ok
@@ -1,1 +1,1 @@
-parse error at 1:1: global var "ShowMe" can't also be a function
+parse error at 14:20: global var "ShowMe" can't also be a function

--- a/testdata/gawk/gsubasgn.ok
+++ b/testdata/gawk/gsubasgn.ok
@@ -1,1 +1,1 @@
-parse error at 1:1: global var "test1" can't also be a function
+parse error at 4:35: global var "test1" can't also be a function

--- a/testdata/gawk/prmarscl.ok
+++ b/testdata/gawk/prmarscl.ok
@@ -1,1 +1,1 @@
-parse error at 6:16: can't pass scalar "j" as array param
+parse error at 6:21: can't pass scalar "j" as array param


### PR DESCRIPTION
This rewrites the type resolver to hopefully be easier to understand and change. We'll see.

Instead of trying to collect all information in a single pass, it now uses two passes:

1) First pass determines function call graph order (topological order).
2) Second pass determines variable type information.

Also:

* Simplify/stabilize "goawk -dt" output and add test
* Remove Scope and Index info from AST (that's a resolver thing)
* Improve error positions for several type errors (hence the updated col:line values in test output)

**Update:** I think this is definitely an improvement, as https://github.com/benhoyt/goawk/pull/176 (`length(x)` working for arrays as well as strings) was *much* simpler to implement with the new version.
