### PR TITLE
Limit ARGC to a reasonable max value

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -781,7 +781,11 @@ func (p *interp) setSpecial(index int, v value) error {
 	case ast.V_FNR:
 		p.fileLineNum = int(v.num())
 	case ast.V_ARGC:
-		p.argc = int(v.num())
+		argc := int(v.num())
+		if argc > maxFieldIndex {
+			return newError("ARGC set too large: %d", argc)
+		}
+		p.argc = argc
 	case ast.V_CONVFMT:
 		p.convertFormat = p.toString(v)
 	case ast.V_FILENAME:

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -305,6 +305,7 @@ BEGIN {
 
 	// Built-in variables
 	{`BEGIN { print ARGC; ARGC=42; print ARGC }  # !gawk`, "", "1\n42\n", "", ""}, // ARGC is properly tested in goawk_test.go
+	{`BEGIN { ARGC=1234567 }`, "", "", "ARGC set too large: 1234567", ""},
 	{`
 BEGIN {
 	print CONVFMT, 1.2345678 ""


### PR DESCRIPTION
This is to prevent scripts like `ARGC=100000000` from taking forever. There are still lots of ways to make a script that runs for ages / forever of course, but it seems like we shouldn't allow arbitrarily large `ARGC` values.