### PR TITLE
Abstract redirects and pipes into inputStream and outputStream interface

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -234,9 +234,6 @@ func TestGAWK(t *testing.T) {
 
 		"gsubtst7":     true, // something wrong with gsub or field split/join
 		"splitwht":     true, // other awks handle split(s, a, " ") differently from split(s, a, / /)
-		"status-close": true, // hmmm, not sure what's up here
-		"sigpipe1":     true, // probable race condition: sometimes fails, sometimes passes
-
 		"parse1": true, // incorrect parsing of $$a++++ (see TODOs in interp_test.go too)
 
 		"rscompat": true, // GoAWK allows multi-char RS by default
@@ -251,6 +248,7 @@ func TestGAWK(t *testing.T) {
 		"eofsplit": true, // reads from /etc/passwd
 		"getline5": true, // removes a file while it's open
 		"iobug1":   true, // reads from /dev/null
+		"sigpipe1": true, // requires POSIX signals
 	}
 
 	sortLines := map[string]bool{

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"os/exec"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -80,9 +79,8 @@ type interp struct {
 	hadFiles      bool
 	input         io.Reader
 	inputBuffer   []byte
-	inputStreams  map[string]io.ReadCloser
-	outputStreams map[string]io.WriteCloser
-	commands      map[string]*exec.Cmd
+	inputStreams  map[string]inputStream
+	outputStreams map[string]outputStream
 	noExec        bool
 	noFileWrites  bool
 	noFileReads   bool
@@ -392,9 +390,8 @@ func newInterp(program *parser.Program) *interp {
 	p.outputRecordSep = "\n"
 	p.subscriptSep = "\x1c"
 
-	p.inputStreams = make(map[string]io.ReadCloser)
-	p.outputStreams = make(map[string]io.WriteCloser)
-	p.commands = make(map[string]*exec.Cmd)
+	p.inputStreams = make(map[string]inputStream)
+	p.outputStreams = make(map[string]outputStream)
 	p.scanners = make(map[string]*bufio.Scanner)
 
 	return p

--- a/interp/iostream.go
+++ b/interp/iostream.go
@@ -1,0 +1,224 @@
+package interp
+
+// I/O streams are interfaces which allow file redirects and command pipelines to be treated
+// equivalently.
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os/exec"
+	"syscall"
+)
+
+const (
+	notClosedExitCode = -127
+)
+
+var (
+	doubleCloseError = errors.New("close: stream already closed")
+)
+
+// firstError returns the first non-nil error or nil if all errors are nil.
+func firstError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close the cmd and convert the error result into the result returned from goawk builtin functions.
+// A nil error is returned if that error describes a non-zero exit status or an unhandled signal.
+// Any other type of error returns -1 and err.
+//
+// The result mimicks gawk for expected child process errors:
+// 1. Returns the exit status of the child process and nil error on normal process exit.
+// 2. Returns 256 + signal on unhandled signal exit.
+// 3. Returns 512 + signal on unhandled signal exit which caused a core dump.
+func waitExitCode(cmd *exec.Cmd) (int, error) {
+	err := cmd.Wait()
+	if err == nil {
+		return 0, nil
+	}
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		// Wait() returned an io error.
+		return -1, err
+	}
+	status, ok := ee.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		// Maybe not all platforms support WaitStatus?
+		return -1, err
+	}
+	switch {
+	case status.CoreDump():
+		return 512 + int(status.Signal()), nil
+	case status.Signaled():
+		return 256 + int(status.Signal()), nil
+	case status.Exited():
+		return status.ExitStatus(), nil
+	default:
+		return -1, err
+	}
+}
+
+type inputStream interface {
+	io.ReadCloser
+	ExitCode() int
+}
+
+type outputStream interface {
+	io.WriteCloser
+	Flush() error
+	ExitCode() int
+}
+
+type outFileStream struct {
+	*bufio.Writer
+	closer   io.Closer
+	exitCode int
+	closed   bool
+}
+
+func newOutFileStream(wc io.WriteCloser, size int) outputStream {
+	b := bufio.NewWriterSize(wc, size)
+	return &outFileStream{b, wc, notClosedExitCode, false}
+}
+
+func (s *outFileStream) Close() error {
+	if s.closed {
+		return doubleCloseError
+	}
+	s.closed = true
+	flushErr := s.Writer.Flush()
+	closeErr := s.closer.Close()
+	if err := firstError(flushErr, closeErr); err != nil {
+		s.exitCode = -1
+		return err
+	}
+	s.exitCode = 0
+	return nil
+}
+
+func (s *outFileStream) ExitCode() int {
+	return s.exitCode
+}
+
+type outCmdStream struct {
+	*bufio.Writer
+	closer   io.Closer
+	cmd      *exec.Cmd
+	exitCode int
+	closed   bool
+}
+
+func newOutCmdStream(cmd *exec.Cmd) (outputStream, error) {
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, newError("error connecting to stdin pipe: %v", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		w.Close()
+		return nil, err
+	}
+	out := &outCmdStream{bufio.NewWriterSize(w, outputBufSize), w, cmd, notClosedExitCode, false}
+	return out, nil
+}
+
+func (s *outCmdStream) Close() error {
+	if s.closed {
+		return doubleCloseError
+	}
+	s.closed = true
+	flushErr := s.Writer.Flush()
+	closeErr := s.closer.Close()
+	var waitErr error
+	s.exitCode, waitErr = waitExitCode(s.cmd)
+	return firstError(waitErr, flushErr, closeErr)
+}
+
+func (s *outCmdStream) ExitCode() int {
+	return s.exitCode
+}
+
+// An outNullStream allows writes to not do anything while fulfilling the outputStream interface.
+type outNullStream struct {
+	io.Writer
+	closed bool
+}
+
+func newOutNullStream() outputStream { return &outNullStream{io.Discard, false} }
+func (s outNullStream) Flush() error { return nil }
+func (s *outNullStream) Close() error {
+	if s.closed {
+		return doubleCloseError
+	}
+	s.closed = true
+	return nil
+}
+func (s outNullStream) ExitCode() int { return -1 }
+
+type inFileStream struct {
+	io.ReadCloser
+	exitCode int
+	closed   bool
+}
+
+func newInFileStream(rc io.ReadCloser) inputStream {
+	return &inFileStream{rc, notClosedExitCode, false}
+}
+
+func (s *inFileStream) Close() error {
+	if s.closed {
+		return doubleCloseError
+	}
+	s.closed = true
+	if err := s.ReadCloser.Close(); err != nil {
+		s.exitCode = -1
+		return err
+	}
+	s.exitCode = 0
+	return nil
+}
+
+func (s *inFileStream) ExitCode() int {
+	return s.exitCode
+}
+
+type inCmdStream struct {
+	io.ReadCloser
+	cmd      *exec.Cmd
+	exitCode int
+	closed   bool
+}
+
+func newInCmdStream(cmd *exec.Cmd) (inputStream, error) {
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, newError("error connecting to stdout pipe: %v", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		r.Close()
+		return nil, err
+	}
+	return &inCmdStream{r, cmd, notClosedExitCode, false}, nil
+}
+
+func (s *inCmdStream) Close() error {
+	if s.closed {
+		return doubleCloseError
+	}
+	s.closed = true
+	closeErr := s.ReadCloser.Close()
+	var waitErr error
+	s.exitCode, waitErr = waitExitCode(s.cmd)
+	return firstError(waitErr, closeErr)
+}
+
+func (s *inCmdStream) ExitCode() int {
+	return s.exitCode
+}

--- a/interp/iostream_test.go
+++ b/interp/iostream_test.go
@@ -1,0 +1,73 @@
+package interp
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	outputStreamBufferSize = 1024
+)
+
+func TestStreamDoubleClose(t *testing.T) {
+	dir := t.TempDir()
+	t.Run("InFile", func(t *testing.T) {
+		f, err := os.Create(filepath.Join(dir, "infile"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		in := newInFileStream(f)
+		checkDoubleClose(t, in)
+	})
+	t.Run("OutFile", func(t *testing.T) {
+		f, err := os.Create(filepath.Join(dir, "outfile"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := newOutFileStream(f, outputStreamBufferSize)
+		checkDoubleClose(t, out)
+	})
+	t.Run("InCmd", func(t *testing.T) {
+		cmd := execDefaultShell("echo close me")
+		in, err := newInCmdStream(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checkDoubleClose(t, in)
+	})
+	t.Run("OutCmd", func(t *testing.T) {
+		cmd := execDefaultShell("echo close me")
+		out, err := newOutCmdStream(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checkDoubleClose(t, out)
+	})
+}
+
+func execDefaultShell(scriptlet string) *exec.Cmd {
+	cmdline := append(defaultShellCommand, scriptlet)
+	return exec.Command(cmdline[0], cmdline[1:]...)
+}
+
+type streamCloser interface {
+	ExitCode() int
+	Close() error
+}
+
+func checkDoubleClose(t *testing.T, sc streamCloser) {
+	t.Helper()
+	if err := sc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	exitCode := sc.ExitCode()
+	if err := sc.Close(); !errors.Is(err, doubleCloseError) {
+		t.Error("expected stream.Close() to return error on double close")
+	}
+	if sc.ExitCode() != exitCode {
+		t.Error("expected stream.ExitCode() to stay the same")
+	}
+}

--- a/interp/newexecute.go
+++ b/interp/newexecute.go
@@ -96,9 +96,6 @@ func (p *interp) resetCore() {
 	for k := range p.outputStreams {
 		delete(p.outputStreams, k)
 	}
-	for k := range p.commands {
-		delete(p.commands, k)
-	}
 
 	p.sp = 0
 	p.localArrays = p.localArrays[:0]


### PR DESCRIPTION
This creates the `inputStream` and `outputStream` interfaces which are satisfied by structs for all combinations of file/pipe and input/output:

1. Input File - `struct inFileStream`
2. Input Command - `struct inCmdStream`
3. Output File - `struct outFileStream`
4. Output Command - `struct outCmdStream`

The streams satisfy the `io.ReadCloser` and `io.WriteCloser` interfaces while the `outputStream` also has a `Flush() error` method. Both types of streams also have an `ExitCode() int` method which makes it trivial to determine the result of a `close()` on those streams.

This PR homogenizes behavior and fixes a number of minor issues related to command pipes. Gawk behavior is mimicked for the following:

1. The exit status of the child process is returned from `close()` when closing a pipe. Exit due to signal is `256 + signal` and if both a signal and coredump occurred it is `512 + signal`. (see #203)
2. The same rules apply to the result of the `system()` builtin function. (see #205)

A separate bug was fixed so that the child process information is cleaned up when `close()` is called on an input pipe (i.e. via `getline`). (see #204)