### PR TITLE
flushAll() stops flushing on first error

### DIFF
--- a/interp/io.go
+++ b/interp/io.go
@@ -865,11 +865,12 @@ func (p *interp) closeAll() {
 func (p *interp) flushAll() bool {
 	allGood := true
 	for name, writer := range p.outputStreams {
-		allGood = allGood && p.flushWriter(name, writer)
+		if !p.flushWriter(name, writer) {
+			allGood = false
+		}
 	}
-	if _, ok := p.output.(flusher); ok {
-		// User-provided output may or may not be flushable
-		allGood = allGood && p.flushWriter("stdout", p.output)
+	if !p.flushWriter("stdout", p.output) {
+		allGood = false
 	}
 	return allGood
 }


### PR DESCRIPTION
The && operator causes conditional evaluation (aka "short-circuiting"). This means if the left-hand-side is false the right hand side is not evaluated. If any call to interp.flushWriter returns false then all streams following that stream in the range, as well as interp.output, will not be flushed.

Removes the type cast to the flusher interface because that is done in interp.flushWriter. This check would be performed twice for any interp.output value whose type implements the interface.

Fixes #208