### PR TITLE
Add support for new Unicode string escape \u

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -269,6 +269,7 @@ BEGIN {
 	{`BEGIN { print 1, 1., .1, 1e0, -1, 1e }`, "", "1 1 0.1 1 -1 1\n", "", ""},
 	{`BEGIN { print '\"' '\'' 'xy' "z" "'" '\"' }`, "", "\"'xyz'\"\n", "", "invalid char"}, // Check support for single-quoted strings
 	{`BEGIN { print "0\n1\t2\r3\a4\b5\f6\v7\x408\xf" }  # !posix`, "", "0\n1\t2\r3\a4\b5\f6\v7@8\x0f\n", "", ""},
+	{`BEGIN { print "The \u201cQUICK\u201d brown fox \u1F602" }  # !gawk`, "", "The “QUICK” brown fox 😂\n", "", ""},
 	{`{ print /foo/ }`, "food\nfoo\nxfooz\nbar\n", "1\n1\n1\n0\n", "", ""},
 	{`/[a-/`, "foo", "", "parse error at 1:1: error parsing regexp: invalid character class range: `a-)`", "terminated"},
 	{`/\Q/  # !gawk`, "", "", "parse error at 1:1: error parsing regexp: missing closing ): `(?s:\\Q)`", ""}, // Gawk produces a warning (not an error), so skip

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -500,8 +500,9 @@ func parseString(quote byte, ch func() byte, next func()) (string, error) {
 			if !utf8.ValidRune(rune(r)) {
 				return "", errors.New("invalid Unicode character")
 			}
-			runeBytes := utf8.AppendRune(nil, rune(r))
-			chars = append(chars, runeBytes...)
+			runeBytes := make([]byte, utf8.UTFMax)
+			n := utf8.EncodeRune(runeBytes, rune(r))
+			chars = append(chars, runeBytes[:n]...)
 			continue
 		case '0', '1', '2', '3', '4', '5', '6', '7':
 			// Octal byte of 1-3 octal digits

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -10,6 +10,7 @@ package lexer
 import (
 	"errors"
 	"fmt"
+	"unicode/utf8"
 )
 
 // Lexer tokenizes a byte string of AWK source code. Use NewLexer to
@@ -467,7 +468,7 @@ func parseString(quote byte, ch func() byte, next func()) (string, error) {
 			c = '\v'
 			next()
 		case 'x':
-			// Hex byte of one of two hex digits
+			// Hex byte of one or two hex digits
 			next()
 			digit := hexDigit(ch())
 			if digit < 0 {
@@ -480,6 +481,28 @@ func parseString(quote byte, ch func() byte, next func()) (string, error) {
 				c = c*16 + byte(digit)
 				next()
 			}
+		case 'u':
+			// Hex Unicode character of 1-8 digits
+			next()
+			r := hexDigit(ch())
+			if r < 0 {
+				return "", errors.New("1-8 hex digits expected")
+			}
+			next()
+			for i := 0; i < 7; i++ {
+				digit := hexDigit(ch())
+				if digit < 0 {
+					break
+				}
+				next()
+				r = r*16 + digit
+			}
+			if !utf8.ValidRune(rune(r)) {
+				return "", errors.New("invalid Unicode character")
+			}
+			runeBytes := utf8.AppendRune(nil, rune(r))
+			chars = append(chars, runeBytes...)
+			continue
 		case '0', '1', '2', '3', '4', '5', '6', '7':
 			// Octal byte of 1-3 octal digits
 			c = ch() - '0'


### PR DESCRIPTION
See similar onetrueawk and Gawk changes:
- https://github.com/onetrueawk/awk/commit/ac3084de9b64d0c838e520ea1ebdb2e1bde87b3f
- https://git.savannah.gnu.org/cgit/gawk.git/commit/?id=1bc73bfb10f0600aaccca7220b5200e220f9a71a

Also, in lexer tests, stop after first error.

Fixes #210