### PR TITLE
Fix rare race in pipe-to-command close() result test

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -843,9 +843,9 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 	{`BEGIN { print >"out"; close("out"); getline <"out"; print |"out" }  # !awk !gawk`, "", "", "can't write to reader stream", ""},
 
 	// The value of close() on a pipe emulates gawk behavior. Results are identical for both
-	// input and output. Windows does not do POSIX signals.
-	{`BEGIN { cmd="exit 9"; print "" |cmd; print close(cmd) } # !awk !posix`, "", "9\n", "", ""},
-	{`BEGIN { cmd="exec /bin/kill -9 $$"; print "" |cmd; print close(cmd) } # !awk !posix !windows`, "", "265\n", "", ""},
+	// input and output. Windows does not do POSIX signals. Windows gawk uses cmd.exe, not sh.exe.
+	{`BEGIN { cmd="read FOO; exit 9"; print "" |cmd; print close(cmd) } # !awk !posix !windows-gawk`, "", "9\n", "", ""},
+	{`BEGIN { cmd="read FOO; exec /bin/kill -9 $$"; print "" |cmd; print close(cmd) } # !awk !posix !windows`, "", "265\n", "", ""},
 	{`BEGIN { cmd="exit 9"; cmd |getline; print close(cmd) } # !awk !posix`, "", "9\n", "", ""},
 	{`BEGIN { cmd="exec /bin/kill -9 $$"; cmd |getline; print close(cmd) } # !awk !posix !windows`, "", "265\n", "", ""},
 


### PR DESCRIPTION
Here a fix for the test race condition in #206 and the test fail for Linux:

https://github.com/benhoyt/goawk/actions/runs/6293036690/job/17083040381.

I was able to reproduce on my older Macbook and Go 1.17 using `go test -count 1000 -run='TestInterp/^BEGIN { cmd'`... but not consistently. In my case the other pipe-to-command test failed (the one which uses `/bin/kill`) but with the same pipe error.

Analysis/commit message follows:

The bufio.Writer does not write to the Cmd pipe until Flush is called when the Cmd is Wait-ed on. This causes a Flush error but not a Wait error. This only happens if the Cmd starts and exits before the Flush can be called by goawk.

