### PR TITLE
Fix #190: FS regex [^,]* fails on empty field

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -65,6 +65,12 @@ NR==2, NR==4 { print $0 }
 NR==3, NR==5 { print NR }
 `, "a\nb\nc\nd\ne\nf\ng", "b\nc\n3\nd\n4\n5\n", "", ""},
 
+	// field separator cannot match empty field
+	{`BEGIN {FS = "[^,]*"} {for (i=1;i<=NF;i++) print i, "<"$i">"}`, `x,,z`, "1 <>\n2 <,,>\n3 <>\n", "", ""},
+	{`BEGIN {FS = "[^a-z]*"} {for (i=1;i<=NF;i++) print i, "<"$i">"}`, `xyz`, "1 <xyz>\n", "", ""},
+	{`BEGIN {FS = "[0-9]*"} {for (i=1;i<=NF;i++) print i, "<"$i">"}`, `xyz`, "1 <xyz>\n", "", ""},
+	{`BEGIN {FS = "(abc)?"} {for (i=1;i<=NF;i++) print i, "<"$i">"}`, `abcdef`, "1 <>\n2 <def>\n", "", ""},
+
 	// print and printf statements
 	{`BEGIN { print "x", "y" }`, "", "x y\n", "", ""},
 	{`BEGIN { print OFS; OFS = ","; print "x", "y" }`, "", " \nx,y\n", "", ""},

--- a/interp/io.go
+++ b/interp/io.go
@@ -618,8 +618,9 @@ func (p *interp) setLine(line string, isTrueStr bool) {
 	p.reparseCSV = true
 }
 
-func (p *interp) customFieldSepRegexSplit(line string) []string {
-	var result []string
+// Splits on FS as a regex, appending each field to fields and returning the
+// new slice (for efficiency).
+func (p *interp) splitOnFieldSepRegex(fields []string, line string) []string {
 	indices := p.fieldSepRegex.FindAllStringIndex(line, -1)
 	prevIndex := 0
 	for _, match := range indices {
@@ -628,11 +629,11 @@ func (p *interp) customFieldSepRegexSplit(line string) []string {
 		if start == end {
 			continue
 		}
-		result = append(result, line[prevIndex:start])
+		fields = append(fields, line[prevIndex:start])
 		prevIndex = end
 	}
-	result = append(result, line[prevIndex:])
-	return result
+	fields = append(fields, line[prevIndex:])
+	return fields
 }
 
 // Ensure that the current line is parsed into fields, splitting it
@@ -671,7 +672,7 @@ func (p *interp) ensureFields() {
 		p.fields = strings.Split(p.line, p.fieldSep)
 	default:
 		// Split on FS as a regex
-		p.fields = p.customFieldSepRegexSplit(p.line)
+		p.fields = p.splitOnFieldSepRegex(p.fields[:0], p.line)
 	}
 
 	// Special case for when RS=="" and FS is single character,


### PR DESCRIPTION
This pull request fixes issue #190 by introducing a custom split function that skips empty matches (according to https://www.austingroupbugs.net/view.php?id=1468, this is the correct behaviour). It is used only for FS

Fixes #190