### PR TITLE
Fix wrong precedence of 'expr | getline' expressions

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -229,9 +229,6 @@ func sortedLines(data []byte) []byte {
 
 func TestGAWK(t *testing.T) {
 	skip := map[string]bool{ // TODO: fix these (at least the ones that are bugs)
-		"getline":  true, // getline syntax issues (may be okay, see grammar notes at http://pubs.opengroup.org/onlinepubs/007904975/utilities/awk.html#tag_04_06_13_14)
-		"getline3": true, // getline syntax issues (similar to above)
-
 		"gsubtst7": true, // something wrong with gsub or field split/join
 		"splitwht": true, // other awks handle split(s, a, " ") differently from split(s, a, / /)
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -830,9 +830,11 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 	{`BEGIN { print getline x+1; print x }`, "foo", "2\nfoo\n", "", ""},
 	{`BEGIN { print getline (x+1); print $0 }`, "foo", "11\nfoo\n", "", ""},
 	{`BEGIN { print getline foo(); print $0 } function foo() { print "z" }`, "foo", "z\n1\nfoo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline x+1); print x }`, "", "2\nfoo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline $0+1); print }`, "", "2\nfoo\n", "", ""},
+	{`BEGIN { while ("echo foo" | getline > 0) print }`, "", "foo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline * 100) }`, "", "100\n", "", ""},
 	// TODO: these forms don't yet work under GoAWK
-	//{`BEGIN { print("echo foo" | getline x+1); print x }`, "", "2\nfoo\n", "", ""},
-	//{`BEGIN { print("echo foo" | getline $0+1); print }`, "", "2\nfoo\n", "", ""},
 	//{`BEGIN { print("echo foo" | getline ($0+1)); print }`, "", "11\nfoo\n", "", ""},
 	//{`BEGIN { print("echo foo" | getline foo()); print } function foo() { print "z" }`, "", "z\n1\nfoo\n", "", ""},
 	{`BEGIN {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -830,11 +830,10 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 	{`BEGIN { print getline x+1; print x }`, "foo", "2\nfoo\n", "", ""},
 	{`BEGIN { print getline (x+1); print $0 }`, "foo", "11\nfoo\n", "", ""},
 	{`BEGIN { print getline foo(); print $0 } function foo() { print "z" }`, "foo", "z\n1\nfoo\n", "", ""},
-	// TODO: these forms don't yet work under GoAWK
-	//{`BEGIN { print("echo foo" | getline x+1); print x }`, "", "2\nfoo\n", "", ""},
-	//{`BEGIN { print("echo foo" | getline $0+1); print }`, "", "2\nfoo\n", "", ""},
-	//{`BEGIN { print("echo foo" | getline ($0+1)); print }`, "", "11\nfoo\n", "", ""},
-	//{`BEGIN { print("echo foo" | getline foo()); print } function foo() { print "z" }`, "", "z\n1\nfoo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline x+1); print x }`, "", "2\nfoo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline $0+1); print }`, "", "2\nfoo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline ($0+1)); print }`, "", "11\nfoo\n", "", ""},
+	{`BEGIN { print("echo foo" | getline foo()); print } function foo() { print "z" }`, "", "z\n1\nfoo\n", "", ""},
 	{`BEGIN {
 	print "foo" >"out"
 	print close("out")

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -830,11 +830,9 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 	{`BEGIN { print getline x+1; print x }`, "foo", "2\nfoo\n", "", ""},
 	{`BEGIN { print getline (x+1); print $0 }`, "foo", "11\nfoo\n", "", ""},
 	{`BEGIN { print getline foo(); print $0 } function foo() { print "z" }`, "foo", "z\n1\nfoo\n", "", ""},
-	{`BEGIN { print("echo foo" | getline x+1); print x }`, "", "2\nfoo\n", "", ""},
-	{`BEGIN { print("echo foo" | getline $0+1); print }`, "", "2\nfoo\n", "", ""},
-	{`BEGIN { while ("echo foo" | getline > 0) print }`, "", "foo\n", "", ""},
-	{`BEGIN { print("echo foo" | getline * 100) }`, "", "100\n", "", ""},
 	// TODO: these forms don't yet work under GoAWK
+	//{`BEGIN { print("echo foo" | getline x+1); print x }`, "", "2\nfoo\n", "", ""},
+	//{`BEGIN { print("echo foo" | getline $0+1); print }`, "", "2\nfoo\n", "", ""},
 	//{`BEGIN { print("echo foo" | getline ($0+1)); print }`, "", "11\nfoo\n", "", ""},
 	//{`BEGIN { print("echo foo" | getline foo()); print } function foo() { print "z" }`, "", "z\n1\nfoo\n", "", ""},
 	{`BEGIN {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -931,6 +931,8 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 
 	// Ensure syntax errors result in errors
 	{`{ $1 = substr($1, 1, 3) print $1 }`, "", "", "parse error at 1:25: expected ; or newline between statements", "syntax error"},
+	{`BEGIN { 1 + 1 - | }`, "", "", `parse error at 1:17: expected expression instead of |`, "syntax"},
+	{`BEGIN { | }`, "", "", `parse error at 1:9: expected expression instead of |`, "syntax"},
 	{`BEGIN { f() }`, "", "", `parse error at 1:9: undefined function "f"`, "defined"},
 	{`function f() {} function f() {} BEGIN { }`, "", "", `parse error at 1:26: function "f" already defined`, "define"},
 	{`BEGIN { print (1,2),(3,4) }`, "", "", "parse error at 1:15: unexpected comma-separated expression", "syntax"},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -525,34 +525,12 @@ func (p *parser) printExpr() ast.Expr { return p._assign(p.printCond) }
 //
 //	assign [PIPE GETLINE [lvalue]]
 func (p *parser) getLine() ast.Expr {
-	var expr ast.Expr
-	expr = p._assign(p.cond)
+	expr := p._assign(p.cond)
 	if p.tok == PIPE {
 		p.next()
 		p.expect(GETLINE)
 		target := p.optionalLValue()
-		expr = &ast.GetlineExpr{expr, target, nil}
-		if p.matches(
-			ADD,
-			SUB,
-			MUL,
-			DIV,
-			POW,
-			AND,
-			OR,
-			MATCH,
-			NOT_MATCH,
-			EQUALS,
-			NOT_EQUALS,
-			GREATER,
-			GTE,
-			LESS,
-			LTE,
-		) {
-			op := p.tok
-			p.next()
-			expr = &ast.BinaryExpr{expr, op, p.expr()}
-		}
+		return &ast.GetlineExpr{expr, target, nil}
 	}
 	return expr
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -525,12 +525,34 @@ func (p *parser) printExpr() ast.Expr { return p._assign(p.printCond) }
 //
 //	assign [PIPE GETLINE [lvalue]]
 func (p *parser) getLine() ast.Expr {
-	expr := p._assign(p.cond)
+	var expr ast.Expr
+	expr = p._assign(p.cond)
 	if p.tok == PIPE {
 		p.next()
 		p.expect(GETLINE)
 		target := p.optionalLValue()
-		return &ast.GetlineExpr{expr, target, nil}
+		expr = &ast.GetlineExpr{expr, target, nil}
+		if p.matches(
+			ADD,
+			SUB,
+			MUL,
+			DIV,
+			POW,
+			AND,
+			OR,
+			MATCH,
+			NOT_MATCH,
+			EQUALS,
+			NOT_EQUALS,
+			GREATER,
+			GTE,
+			LESS,
+			LTE,
+		) {
+			op := p.tok
+			p.next()
+			expr = &ast.BinaryExpr{expr, op, p.expr()}
+		}
 	}
 	return expr
 }


### PR DESCRIPTION
This pull request modifies `getLine()` inside parser.go so that it lets binary operators come after 'expr | getline' expressions.

I also uncommented two tests that were in TODO inside interp_test.go and added two new tests.

There were two other tests under the same TODO: (`BEGIN { print("echo foo" | getline ($0+1)); print }` and `BEGIN { print("echo foo" | getline foo()); print } function foo() { print "z" }`), but those address a separate issue.

Fixes #189 