### PR TITLE
Allow optional newline between "do {}" and "while"

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -155,6 +155,7 @@ NR==3, NR==5 { print NR }
 	{`BEGIN { s="x"; while (s=="x") { print s; s="y" } }`, "", "x\n", "", ""},
 	{`BEGIN { s="x"; while (s!="") { print s; s="" } }`, "", "x\n", "", ""},
 	{`BEGIN { s="x"; while (s) { print s; s="" } }`, "", "x\n", "", ""},
+	{"BEGIN { do { print 1 }\nwhile (0) }", "", "1\n", "", ""},
 	// regression tests for break and continue with nested loops
 	{`
 BEGIN {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -379,6 +379,7 @@ func (p *parser) stmt() ast.Stmt {
 		p.next()
 		p.optionalNewlines()
 		body := p.loopStmts()
+		p.optionalNewlines()
 		p.expect(WHILE)
 		p.expect(LPAREN)
 		cond := p.expr()


### PR DESCRIPTION
Fixes #219. Thanks @oguz-ismail for the report.