### PR TITLE
Distinguish between /regexp/ and "regexp" in stringified output

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -292,12 +292,17 @@ func (e *NumExpr) String() string {
 	}
 }
 
-// StrExpr is a literal string like "foo".
+// StrExpr is a literal string like "foo" or a regexp constant like /foo/.
 type StrExpr struct {
-	Value string
+	Value  string
+	Regexp bool
 }
 
 func (e *StrExpr) String() string {
+	if e.Regexp {
+		r := &RegExpr{e.Value}
+		return r.String()
+	}
 	return strconv.Quote(e.Value)
 }
 

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -300,8 +300,7 @@ type StrExpr struct {
 
 func (e *StrExpr) String() string {
 	if e.Regexp {
-		r := &RegExpr{e.Value}
-		return r.String()
+		return formatRegex(e.Value)
 	}
 	return strconv.Quote(e.Value)
 }
@@ -313,8 +312,7 @@ type RegExpr struct {
 }
 
 func (e *RegExpr) String() string {
-	escaped := strings.Replace(e.Regex, "/", `\/`, -1)
-	return "/" + escaped + "/"
+	return formatRegex(e.Regex)
 }
 
 // VarExpr is a variable reference (special var, global, or local).
@@ -463,6 +461,12 @@ func IsLValue(expr Expr) bool {
 	default:
 		return false
 	}
+}
+
+// formatRegex formats the regex string r.
+func formatRegex(r string) string {
+	escaped := strings.Replace(r, "/", `\/`, -1)
+	return "/" + escaped + "/"
 }
 
 // Stmt is the abstract syntax tree for any AWK statement.

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -292,14 +292,14 @@ func (e *NumExpr) String() string {
 	}
 }
 
-// StrExpr is a literal string like "foo" or a regexp constant like /foo/.
+// StrExpr is a literal string like "foo" or a regex constant like /foo/.
 type StrExpr struct {
-	Value  string
-	Regexp bool
+	Value string
+	Regex bool
 }
 
 func (e *StrExpr) String() string {
-	if e.Regexp {
+	if e.Regex {
 		return formatRegex(e.Value)
 	}
 	return strconv.Quote(e.Value)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -726,7 +726,7 @@ func (p *parser) primary() ast.Expr {
 	case STRING:
 		s := p.val
 		p.next()
-		return &ast.StrExpr{s}
+		return &ast.StrExpr{Value: s}
 	case DIV, DIV_ASSIGN:
 		// If we get to DIV or DIV_ASSIGN as a primary expression,
 		// it's actually a regex.
@@ -967,7 +967,7 @@ func (p *parser) optionalLValue() ast.Expr {
 func (p *parser) regexStr(parse func() ast.Expr) ast.Expr {
 	if p.matches(DIV, DIV_ASSIGN) {
 		regex := p.nextRegex()
-		return &ast.StrExpr{regex}
+		return &ast.StrExpr{Value: regex, Regexp: true}
 	}
 	return parse()
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -967,7 +967,7 @@ func (p *parser) optionalLValue() ast.Expr {
 func (p *parser) regexStr(parse func() ast.Expr) ast.Expr {
 	if p.matches(DIV, DIV_ASSIGN) {
 		regex := p.nextRegex()
-		return &ast.StrExpr{Value: regex, Regexp: true}
+		return &ast.StrExpr{Value: regex, Regex: true}
 	}
 	return parse()
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -124,6 +124,8 @@ $0 {
     a[x, y, z]
     f()
     set(a, k, v)
+    sub(/regex/, repl, s)
+    sub("regex", repl, s)
     sub(regex, repl)
     sub(regex, repl, s)
     gsub(regex, repl)


### PR DESCRIPTION
Fixes issue #221
