### PR TITLE
Make redirecting to /dev/stderr work on Windows

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1572,9 +1572,10 @@ func TestDevStderrWindows(t *testing.T) {
 	if outBuf.String() != "" {
 		t.Fatalf("expected empty stdout, got %q", outBuf.String())
 	}
+	gotError := normalizeNewlines(errBuf.String())
 	expectedError := "Error!\n"
-	if errBuf.String() != expectedError {
-		t.Fatalf("expected stderr %q, got %q", expectedError, errBuf.String())
+	if gotError != expectedError {
+		t.Fatalf("expected stderr %q, got %q", expectedError, gotError)
 	}
 }
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1551,6 +1551,33 @@ func TestShellCommand(t *testing.T) {
 	}
 }
 
+func TestDevStderrWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("skipping on non-Windows platform")
+	}
+	prog, err := parser.ParseProgram([]byte(`BEGIN { print "Error!" >"/dev/stderr" }`), nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	config := &interp.Config{
+		Output: &outBuf,
+		Error:  &errBuf,
+	}
+	_, err = interp.ExecProgram(prog, config)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if outBuf.String() != "" {
+		t.Fatalf("expected empty stdout, got %q", outBuf.String())
+	}
+	expectedError := "Error!\n"
+	if errBuf.String() != expectedError {
+		t.Fatalf("expected stderr %q, got %q", expectedError, errBuf.String())
+	}
+}
+
 func TestSystemCommandNotFound(t *testing.T) {
 	prog, err := parser.ParseProgram([]byte(`BEGIN { print system("foobar3982") }`), nil)
 	if err != nil {

--- a/interp/io.go
+++ b/interp/io.go
@@ -109,13 +109,17 @@ func (p *interp) getOutputStream(redirect Token, destValue value) (io.Writer, er
 
 	switch redirect {
 	case GREATER, APPEND:
+		// Write or append to file
 		if name == "-" {
 			// filename of "-" means write to stdout, eg: print "x" >"-"
 			return p.output, nil
 		}
-		// Write or append to file
 		if p.noFileWrites {
 			return nil, newError("can't write to file due to NoFileWrites")
+		}
+		if runtime.GOOS == "windows" && name == "/dev/stderr" {
+			// Special case /dev/stderr on Windows to allow portably printing to stderr.
+			return p.errorOutput, nil
 		}
 		p.flushOutputAndError() // ensure synchronization
 		flags := os.O_CREATE | os.O_WRONLY


### PR DESCRIPTION
Fake it till Windows makes it. This enables the common pattern for printing messages to standard error:

    print "An error!" >"/dev/stderr"

To work cross-platform on Windows as well as Unix-based OSs.

Fixes #195