### PR TITLE
Use C.UTF-8 as locale when invoking external awk program

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -481,8 +481,10 @@ func runAWKs(t *testing.T, testArgs []string, testStdin, testOutput, testError s
 	t.Run("awk", func(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command(awkExe, testArgs...)
-		if runtime.GOOS != "windows" {
+		if runtime.GOOS == "darwin" {
 			cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+		} else if runtime.GOOS != "windows" {
+			cmd.Env = []string{"LC_ALL=C.UTF-8"}
 		}
 		if testStdin != "" {
 			cmd.Stdin = strings.NewReader(testStdin)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1101,8 +1101,10 @@ func TestInterp(t *testing.T) {
 				}
 				args = append(args, test.src, "-")
 				cmd := exec.Command(awkExe, args...)
-				if runtime.GOOS != "windows" {
+				if runtime.GOOS == "darwin" {
 					cmd.Env = []string{"LC_ALL=en_US.UTF-8"}
+				} else if runtime.GOOS != "windows" {
+					cmd.Env = []string{"LC_ALL=C.UTF-8"}
 				}
 				if test.in != "" {
 					cmd.Stdin = strings.NewReader(test.in)


### PR DESCRIPTION
The en_US.UTF-8 locale is not guaranteed to be installed, and it quite often isn't by default.

The C.UTF-8 locale was introduced as a Debian-specific locale, but was later upstreamed into glibc 2.35 [1].

This patch fixes failures when running interpreter tests on systems where the en_US.UTF-8 locale is not present. It also changes the locale on goawk_test.go, similar to !174 [2].

1: https://sourceware.org/bugzilla/show_bug.cgi?id=17318
2: https://github.com/benhoyt/goawk/pull/174

---

I ran into some test failures when packaging goawk for Debian. I also ran the
test suite on a fresh Arch container, which failed for the same reason. This
seems like a reasonable fix :^)
