### PR TITLE
Fix evaluation of empty {} and END{}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ interp/testdata
 scripts/csvbench/bin
 scripts/csvbench/count.csv
 /default.pgo
+/goawk-versions


### PR DESCRIPTION
- '{}' shouldn't be equivalent to '{ print $0 }'
- 'END {}' should consume the input

Thanks @oguz-ismail

Fixes #228