### PR TITLE
Make printf %c work on Unicode codepoints

### DIFF
--- a/interp/functions.go
+++ b/interp/functions.go
@@ -411,19 +411,17 @@ func (p *interp) sprintf(format string, args []value) (string, error) {
 		case 'u':
 			v = uint64(a.num())
 		case 'c':
-			var c []byte
+			var c string
 			n, isStr := a.isTrueStr()
 			if isStr {
-				s := p.toString(a)
+				s := []rune(p.toString(a))
 				if len(s) > 0 {
-					c = []byte{s[0]}
+					c = string([]rune{s[0]})
 				} else {
-					c = []byte{0}
+					c = string([]byte{0})
 				}
 			} else {
-				// Follow the behaviour of awk and mawk, where %c
-				// operates on bytes (0-255), not Unicode codepoints
-				c = []byte{byte(n)}
+				c = string([]rune{rune(n)})
 			}
 			v = c
 		}

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -405,23 +405,26 @@ func (p *interp) sprintf(format string, args []value) (string, error) {
 		case 's':
 			v = p.toString(a)
 		case 'd':
-			v = int64(a.num())
+			v = int(a.num())
 		case 'f':
 			v = a.num()
 		case 'u':
-			v = uint64(a.num())
+			v = uint(a.num())
 		case 'c':
-			var c string
+			var c []byte
 			n, isStr := a.isTrueStr()
 			if isStr {
-				s := []rune(p.toString(a))
-				if len(s) > 0 {
-					c = string([]rune{s[0]})
+				s := p.toString(a)
+				_, size := utf8.DecodeRuneInString(s)
+				if size > 0 {
+					c = []byte(s[:size])
 				} else {
-					c = string([]byte{0})
+					c = []byte{0}
 				}
 			} else {
-				c = string([]rune{rune(n)})
+				c = make([]byte, utf8.UTFMax)
+				size := utf8.EncodeRune(c, rune(n))
+				c = c[:size]
 			}
 			v = c
 		}

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -405,11 +405,11 @@ func (p *interp) sprintf(format string, args []value) (string, error) {
 		case 's':
 			v = p.toString(a)
 		case 'd':
-			v = int(a.num())
+			v = int64(a.num())
 		case 'f':
 			v = a.num()
 		case 'u':
-			v = uint(a.num())
+			v = uint64(a.num())
 		case 'c':
 			var c []byte
 			n, isStr := a.isTrueStr()

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -85,14 +85,14 @@ NR==3, NR==5 { print NR }
 	{`BEGIN { printf "%.1g", 42 }  # !windows-gawk`, "", "4e+01", "", ""}, // for some reason gawk gives "4e+001" on Windows
 	{`BEGIN { printf "%d", 12, 34 }`, "", "12", "", ""},
 	{`BEGIN { printf "%d" }`, "", "", "format error: got 0 args, expected 1", "not enough arg"},
-	// Our %c handling is mostly like awk's, except for multiples
-	// 256, where awk is weird, and we're like mawk
 	{`BEGIN { printf "%c", 0 }`, "", "\x00", "", ""},
 	{`BEGIN { printf "%c", 127 }`, "", "\x7f", "", ""},
-	{`BEGIN { printf "%c", 128 }  # !gawk`, "", "\x80", "", ""},
-	{`BEGIN { printf "%c", 255 }  # !gawk`, "", "\xff", "", ""},
-	{`BEGIN { printf "%c", 256 }  # !awk !gawk`, "", "\x00", "", ""},
+	{`BEGIN { printf "%c", 128 }  # !windows-gawk`, "", "\u0080", "", ""},
+	{`BEGIN { printf "%c", 255 }  # !windows-gawk`, "", "ÿ", "", ""},
+	{`BEGIN { printf "%c", 256 }  # !windows-gawk`, "", "Ā", "", ""},
+	{`BEGIN { printf "%c", 4660 }  # !windows-gawk`, "", "\u1234", "", ""},
 	{`BEGIN { printf "%c", "xyz" }`, "", "x", "", ""},
+	{`BEGIN { printf "%c %c %c", "Ā", "ĀĀĀ", "Āx" }  # !windows-gawk`, "", "Ā Ā Ā", "", ""},
 	{`BEGIN { printf "%c", "" }  # !awk`, "", "\x00", "", ""},
 	{`BEGIN { printf }  # !awk !posix - doesn't error on this`, "", "", "parse error at 1:16: expected printf args, got none", "printf: no arguments"},
 	{`BEGIN { printf("%%%dd", 4) }`, "", "%4d", "", ""},


### PR DESCRIPTION
I noticed goawk couldn't handle UTF-8 strings. While there already seems to be ample discussion about this, one of the UTF-8 features that doesn't seem to incur issues about O(n) speed is `printf("%c",[CODEPOINT])` which on the one true awk, Ray Gardner's awk, and gawk, will work with unicode codepoints and utf8 strings:

```
$ for awk in nawk gawk goawk; do $awk 'BEGIN {printf("%c", "ß")}' | xxd; done
00000000: c39f                                     ..
00000000: c39f                                     ..
00000000: c3                                       .
$ for awk in nawk gawk goawk; do $awk 'BEGIN {printf("%c", 400)}' | xxd; done
00000000: c690                                     ..
00000000: c690                                     ..
00000000: 90                                       .
```

This is standard behavior in both the one true awk (since they added unicode support, this feature is mentioned in the second edition awk book) and gawk. Similar to "\u[CODEPOINT]" 
