### PR TITLE
Make srand() use unix time in seconds, and set seed for next srand()

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -616,6 +616,7 @@ BEGIN {
 	print (a==x, b==y, c==z)
 }
 `, "", "0 0 0 0\n1 1 1\n", "", ""},
+	{`BEGIN { s = srand(srand()); print (s > 1700000000) }`, "", "1\n", "", ""},
 	{`
 BEGIN {
 	for (i = 0; i < 1000; i++) {

--- a/interp/vm.go
+++ b/interp/vm.go
@@ -1021,7 +1021,8 @@ func (p *interp) callBuiltin(builtinOp compiler.BuiltinOp) error {
 
 	case compiler.BuiltinSrand:
 		prevSeed := p.randSeed
-		p.random.Seed(time.Now().UnixNano())
+		p.randSeed = float64(time.Now().Unix())
+		p.random.Seed(int64(math.Float64bits(p.randSeed)))
 		p.push(num(prevSeed))
 
 	case compiler.BuiltinSrandSeed:


### PR DESCRIPTION
This is more POSIX-compatible. Fixes #231