### PR TITLE
[std]: fix `system()` for Windows

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -990,11 +990,11 @@ func (p *interp) compileRegex(regex string) (*regexp.Regexp, error) {
 }
 
 func getDefaultShellCommand() []string {
-	executable := "/bin/sh"
+	executable, runcmd := "/bin/sh", "-c"
 	if runtime.GOOS == "windows" {
-		executable = "sh"
+		executable, runcmd = "cmd", "/C"
 	}
-	return []string{executable, "-c"}
+	return []string{executable, runcmd}
 }
 
 func inputModeString(mode IOMode, csvConfig CSVInputConfig) string {


### PR DESCRIPTION
Now resolves to launching `cmd /C` instead of `sh -c`

This, of course, violates the POSIX, which for `system()` states:

>   Execute the command given by expression in a manner equivalent to the
>   `system()` function defined in the System Interfaces volume of
>   POSIX.1-2017 and return the exit status of the command.

Where the `system` function is explicitly `sh`:

>   The system() function shall behave as if a child process were created
>   using fork(), and the child process invoked the **sh** utility using
>   execl() as follows:
>   ```execl(<shell path>, "sh", "-c", command, (char *)0);```