### PR TITLE
fix: compile Nop for empty block regardless of pattern

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -131,16 +131,20 @@ func Compile(resolved *resolver.ResolvedProgram) (compiledProg *Program, err err
 			pattern = append(pattern, c.finish())
 		}
 		var body []Opcode
-		if len(action.Stmts) > 0 {
-			c := compiler{resolved: resolved, program: p, indexes: indexes}
-			c.stmts(action.Stmts)
-			body = c.finish()
-		} else if len(action.Pattern) == 0 {
-			// No action and no pattern (a bare '{}') should have at least one
+		switch {
+		case action.Stmts == nil:
+			// No action block, interpreter will treat this as '{ print $0 }'
+		case len(action.Stmts) == 0:
+			// Empty action block (a bare '{}') should have at least one
 			// opcode, otherwise interpreter will treat it as no action, which
 			// would be evaluated as '{ print $0 }'.
 			c := compiler{resolved: resolved, program: p, indexes: indexes}
 			c.add(Nop)
+			body = c.finish()
+		default:
+			// Regular body such as `{ print $1 }`
+			c := compiler{resolved: resolved, program: p, indexes: indexes}
+			c.stmts(action.Stmts)
 			body = c.finish()
 		}
 		p.Actions = append(p.Actions, Action{

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -50,7 +50,17 @@ var interpTests = []interpTest{
 	{`BEGIN { print "b"} END { print "e" }`, "foo", "b\ne\n", "", ""},
 	{`BEGIN { print "b"} $0 { print NR } END { print "e" }`, "foo", "b\n1\ne\n", "", ""},
 	{`BEGIN { printf "x" }; BEGIN { printf "y" }`, "", "xy", "", ""},
-	{`{}`, "1\n2\n3\n", "", "", ""}, // issue #228
+
+	// Presence of patterns and actions
+	{``, "foo", "", "", ""},                    // no pattern, no action
+	{`0`, "foo", "", "", ""},                   // false pattern, no action
+	{`1`, "foo", "foo\n", "", ""},              // true pattern, no action
+	{`{}`, "foo", "", "", ""},                  // no pattern, empty action (issue #228)
+	{`0 {}`, "foo", "", "", ""},                // false pattern, empty action
+	{`1 {}`, "foo", "", "", ""},                // true pattern, empty action (issue #261)
+	{`{ print $1 }`, "foo", "foo\n", "", ""},   // no pattern, non-empty action
+	{`0 { print $1 }`, "foo", "", "", ""},      // false pattern, non-empty action
+	{`1 { print $1 }`, "foo", "foo\n", "", ""}, // true pattern, non-empty action
 
 	// Patterns
 	{`$0`, "foo\n\nbar", "foo\nbar\n", "", ""},


### PR DESCRIPTION
In PR#230, the fix for #228, I made the wrong fix. It should compile a Nop if action.Stmts is not nil, regardless of pattern.

Add a few more test cases too.

Fixes #261.