### PR TITLE
Ensure split() handles string " " differently from regex / /

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -229,12 +229,11 @@ func sortedLines(data []byte) []byte {
 }
 
 func TestGAWK(t *testing.T) {
-	skip := map[string]bool{ // TODO: fix these (at least the ones that are bugs)
+	skip := map[string]bool{
+		"hex2":     true, // GoAWK allows hex numbers / floating point (per POSIX)
 		"rscompat": true, // GoAWK allows multi-char RS by default
 		"rsstart2": true, // GoAWK ^ and $ anchors match beginning and end of line, not file (unlike Gawk)
-
-		"hex2":   true, // GoAWK allows hex numbers / floating point (per POSIX)
-		"strtod": true, // GoAWK allows hex numbers / floating point (per POSIX)
+		"strtod":   true, // GoAWK allows hex numbers / floating point (per POSIX)
 	}
 
 	dontRunOnWindows := map[string]bool{

--- a/goawk_test.go
+++ b/goawk_test.go
@@ -230,8 +230,6 @@ func sortedLines(data []byte) []byte {
 
 func TestGAWK(t *testing.T) {
 	skip := map[string]bool{ // TODO: fix these (at least the ones that are bugs)
-		"splitwht": true, // other awks handle split(s, a, " ") differently from split(s, a, / /)
-
 		"rscompat": true, // GoAWK allows multi-char RS by default
 		"rsstart2": true, // GoAWK ^ and $ anchors match beginning and end of line, not file (unlike Gawk)
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -802,7 +802,12 @@ func (c *compiler) expr(expr ast.Expr) {
 			scope, index := c.arrayInfo(varExpr.Name)
 			if len(e.Args) > 2 {
 				c.expr(e.Args[2])
-				c.add(CallSplitSep, Opcode(scope), opcodeInt(index))
+				strExpr, isStr := e.Args[2].(*ast.StrExpr)
+				sepIsRegex := 0
+				if isStr && strExpr.Regex {
+					sepIsRegex = 1
+				}
+				c.add(CallSplitSep, Opcode(scope), opcodeInt(index), Opcode(sepIsRegex))
 			} else {
 				c.add(CallSplit, Opcode(scope), opcodeInt(index))
 			}

--- a/internal/compiler/disassembler.go
+++ b/internal/compiler/disassembler.go
@@ -341,7 +341,8 @@ func (d *disassembler) disassemble(prefix string) error {
 		case CallSplitSep:
 			arrayScope := resolver.Scope(d.fetch())
 			arrayIndex := int(d.fetch())
-			d.writeOpf("CallSplitSep %s", d.arrayName(arrayScope, arrayIndex))
+			sepIsRegex := d.fetch()
+			d.writeOpf("CallSplitSep %s %d", d.arrayName(arrayScope, arrayIndex), sepIsRegex)
 
 		case CallSprintf:
 			numArgs := d.fetch()

--- a/internal/compiler/opcodes.go
+++ b/internal/compiler/opcodes.go
@@ -119,7 +119,7 @@ const (
 	CallBuiltin     // builtinOp
 	CallLengthArray // arrayScope arrayIndex
 	CallSplit       // arrayScope arrayIndex
-	CallSplitSep    // arrayScope arrayIndex
+	CallSplitSep    // arrayScope arrayIndex sepIsRegex
 	CallSprintf     // numArgs
 
 	// User and native functions

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -243,7 +243,7 @@ func validNativeType(typ reflect.Type) bool {
 }
 
 // Guts of the split() function
-func (p *interp) split(s string, scope resolver.Scope, index int, fs string, mode IOMode) (int, error) {
+func (p *interp) split(s string, scope resolver.Scope, index int, sep string, sepIsRegex bool, mode IOMode) (int, error) {
 	var parts []string
 	switch {
 	case mode == CSVMode || mode == TSVMode:
@@ -264,14 +264,14 @@ func (p *interp) split(s string, scope resolver.Scope, index int, fs string, mod
 		// Parse one record. Errors shouldn't happen, but if there is one,
 		// len(parts) will be 0.
 		scanner.Scan()
-	case fs == " ":
+	case !sepIsRegex && sep == " ":
 		parts = strings.Fields(s)
 	case s == "":
 		// Leave parts 0 length on empty string
-	case utf8.RuneCountInString(fs) <= 1:
-		parts = strings.Split(s, fs)
+	case !sepIsRegex && utf8.RuneCountInString(sep) <= 1:
+		parts = strings.Split(s, sep)
 	default:
-		re, err := p.compileRegex(fs)
+		re, err := p.compileRegex(sep)
 		if err != nil {
 			return 0, err
 		}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -606,7 +606,9 @@ function f() {
 	{`BEGIN { n = split("ab c d ", a); for (i=1; i<=n; i++) print a[i] }`, "", "ab\nc\nd\n", "", ""},
 	{`BEGIN { n = split("ab,c,d,", a, ","); for (i=1; i<=n; i++) print a[i] }`, "", "ab\nc\nd\n\n", "", ""},
 	{`BEGIN { n = split("ab,c.d,", a, /[,.]/); for (i=1; i<=n; i++) print a[i] }`, "", "ab\nc\nd\n\n", "", ""},
-	{`BEGIN { n = split("aaa", a, /./); print n; for (i=1; i<=n; i++) print a[i] }`, "", "4\n\n\n\n\n", "", ""},
+	// Skip these next two on gawk as older gawk had a bug with /./
+	{`BEGIN { n = split("aaa", a, /./); print n; for (i=1; i<=n; i++) print a[i] }  # !gawk`, "", "4\n\n\n\n\n", "", ""},
+	{`{ n = split($0, a, /./); for (i=1; i<=n; i++) { print i, a[i] } }  # !gawk`, "a.a.a\n", "1 \n2 \n3 \n4 \n5 \n6 \n", "", ""},
 	{`BEGIN { n = split("a b\tc", a, / /); print n; for (i=1; i<=n; i++) print a[i] }`, "", "2\na\nb\tc\n", "", ""},
 	{`BEGIN { n = split("1 2", a); print (n, a[1], a[2], a[1]==1, a[2]==2) }`, "", "2 1 2 1 1\n", "", ""},
 	{`BEGIN { x = "1.2.3"; print sub(/\./, ",", x); print x }`, "", "1\n1,2.3\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -606,6 +606,8 @@ function f() {
 	{`BEGIN { n = split("ab c d ", a); for (i=1; i<=n; i++) print a[i] }`, "", "ab\nc\nd\n", "", ""},
 	{`BEGIN { n = split("ab,c,d,", a, ","); for (i=1; i<=n; i++) print a[i] }`, "", "ab\nc\nd\n\n", "", ""},
 	{`BEGIN { n = split("ab,c.d,", a, /[,.]/); for (i=1; i<=n; i++) print a[i] }`, "", "ab\nc\nd\n\n", "", ""},
+	{`BEGIN { n = split("aaa", a, /./); print n; for (i=1; i<=n; i++) print a[i] }`, "", "4\n\n\n\n\n", "", ""},
+	{`BEGIN { n = split("a b\tc", a, / /); print n; for (i=1; i<=n; i++) print a[i] }`, "", "2\na\nb\tc\n", "", ""},
 	{`BEGIN { n = split("1 2", a); print (n, a[1], a[2], a[1]==1, a[2]==2) }`, "", "2 1 2 1 1\n", "", ""},
 	{`BEGIN { x = "1.2.3"; print sub(/\./, ",", x); print x }`, "", "1\n1,2.3\n", "", ""},
 	{`BEGIN { x = "1.2.3"; print sub(/\./, ",\\", x); print x }`, "", "1\n1,\\2.3\n", "", ""},

--- a/interp/vm.go
+++ b/interp/vm.go
@@ -669,7 +669,7 @@ func (p *interp) execute(code []compiler.Opcode) error {
 			arrayIndex := code[ip+1]
 			ip += 2
 			s := p.toString(p.peekTop())
-			n, err := p.split(s, resolver.Scope(arrayScope), int(arrayIndex), p.fieldSep, p.inputMode)
+			n, err := p.split(s, resolver.Scope(arrayScope), int(arrayIndex), p.fieldSep, false, p.inputMode)
 			if err != nil {
 				return err
 			}
@@ -678,10 +678,11 @@ func (p *interp) execute(code []compiler.Opcode) error {
 		case compiler.CallSplitSep:
 			arrayScope := code[ip]
 			arrayIndex := code[ip+1]
-			ip += 2
+			sepIsRegex := code[ip+2] != 0
+			ip += 3
 			s, fieldSep := p.peekPop()
 			// 3-argument form of split() ignores input mode
-			n, err := p.split(p.toString(s), resolver.Scope(arrayScope), int(arrayIndex), p.toString(fieldSep), DefaultMode)
+			n, err := p.split(p.toString(s), resolver.Scope(arrayScope), int(arrayIndex), p.toString(fieldSep), sepIsRegex, DefaultMode)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- split(in, a, " ") should split like strings.Fields(), trimming whitespace
- split(in, a, / /) should split on a single space

In general, when `/.../` slashes are used, the content is explictly a regex and should be treated as such.

This is as per the other AWKs. (The POSIX spec is a little unclear on this point, but seems to hint at it.)