### PR TITLE
Fix handling of integer special variables

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -108,7 +108,7 @@ type interp struct {
 	fileLineNum     value
 	fields          []string
 	fieldsIsTrueStr []bool
-	numFields       int
+	numFields       value
 	haveFields      bool
 	fieldNames      []string
 	fieldIndexes    map[string]int
@@ -422,6 +422,7 @@ func newInterp(program *parser.Program) *interp {
 	p.subscriptSep = "\x1c"
 	p.lineNum = num(0)
 	p.fileLineNum = num(0)
+	p.numFields = num(0)
 	p.matchStart = num(0)
 	p.matchLength = num(0)
 	// p.argc is initialized in setExecuteConfig based on config.Args
@@ -741,7 +742,7 @@ func (p *interp) getSpecial(index int) value {
 	switch index {
 	case ast.V_NF:
 		p.ensureFields()
-		return num(float64(p.numFields))
+		return p.numFields
 	case ast.V_NR:
 		return p.lineNum
 	case ast.V_RLENGTH:
@@ -806,12 +807,12 @@ func (p *interp) setSpecial(index int, v value) error {
 			return newError("NF set too large: %d", numFields)
 		}
 		p.ensureFields()
-		p.numFields = numFields
-		if p.numFields < len(p.fields) {
-			p.fields = p.fields[:p.numFields]
-			p.fieldsIsTrueStr = p.fieldsIsTrueStr[:p.numFields]
+		p.numFields = v
+		if numFields < len(p.fields) {
+			p.fields = p.fields[:numFields]
+			p.fieldsIsTrueStr = p.fieldsIsTrueStr[:numFields]
 		}
-		for i := len(p.fields); i < p.numFields; i++ {
+		for i := len(p.fields); i < numFields; i++ {
 			p.fields = append(p.fields, "")
 			p.fieldsIsTrueStr = append(p.fieldsIsTrueStr, false)
 		}
@@ -994,7 +995,7 @@ func (p *interp) setField(index int, value string) error {
 	}
 	p.fields[index-1] = value
 	p.fieldsIsTrueStr[index-1] = true
-	p.numFields = len(p.fields)
+	p.numFields = num(float64(len(p.fields)))
 	p.line = p.joinFields(p.fields)
 	p.lineIsTrueStr = true
 	return nil

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -104,8 +104,8 @@ type interp struct {
 	filename        value
 	line            string
 	lineIsTrueStr   bool
-	lineNum         int
-	fileLineNum     int
+	lineNum         value
+	fileLineNum     value
 	fields          []string
 	fieldsIsTrueStr []bool
 	numFields       int
@@ -738,13 +738,13 @@ func (p *interp) getSpecial(index int) value {
 		p.ensureFields()
 		return num(float64(p.numFields))
 	case ast.V_NR:
-		return num(float64(p.lineNum))
+		return p.lineNum
 	case ast.V_RLENGTH:
 		return num(float64(p.matchLength))
 	case ast.V_RSTART:
 		return num(float64(p.matchStart))
 	case ast.V_FNR:
-		return num(float64(p.fileLineNum))
+		return p.fileLineNum
 	case ast.V_ARGC:
 		return num(float64(p.argc))
 	case ast.V_CONVFMT:
@@ -813,13 +813,13 @@ func (p *interp) setSpecial(index int, v value) error {
 		p.line = p.joinFields(p.fields)
 		p.lineIsTrueStr = true
 	case ast.V_NR:
-		p.lineNum = int(v.num())
+		p.lineNum = v
 	case ast.V_RLENGTH:
 		p.matchLength = int(v.num())
 	case ast.V_RSTART:
 		p.matchStart = int(v.num())
 	case ast.V_FNR:
-		p.fileLineNum = int(v.num())
+		p.fileLineNum = v
 	case ast.V_ARGC:
 		argc := int(v.num())
 		if argc > maxFieldIndex {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -115,7 +115,7 @@ type interp struct {
 	reparseCSV      bool
 
 	// Built-in variables
-	argc             int
+	argc             value
 	convertFormat    string
 	outputFormat     string
 	fieldSep         string
@@ -126,8 +126,8 @@ type interp struct {
 	outputFieldSep   string
 	outputRecordSep  string
 	subscriptSep     string
-	matchLength      int
-	matchStart       int
+	matchLength      value
+	matchStart       value
 	inputMode        IOMode
 	csvInputConfig   CSVInputConfig
 	outputMode       IOMode
@@ -420,6 +420,11 @@ func newInterp(program *parser.Program) *interp {
 	p.outputFieldSep = " "
 	p.outputRecordSep = "\n"
 	p.subscriptSep = "\x1c"
+	p.lineNum = num(0)
+	p.fileLineNum = num(0)
+	p.matchStart = num(0)
+	p.matchLength = num(0)
+	// p.argc is initialized in setExecuteConfig based on config.Args
 
 	p.inputStreams = make(map[string]inputStream)
 	p.outputStreams = make(map[string]outputStream)
@@ -476,7 +481,7 @@ func (p *interp) setExecuteConfig(config *Config) error {
 	// Set up ARGV and other variables from config
 	argvIndex := p.arrayIndexes["ARGV"]
 	p.setArrayValue(resolver.Global, argvIndex, "0", str(config.Argv0))
-	p.argc = len(config.Args) + 1
+	p.argc = num(float64(len(config.Args) + 1))
 	for i, arg := range config.Args {
 		p.setArrayValue(resolver.Global, argvIndex, strconv.Itoa(i+1), numStr(arg))
 	}
@@ -740,13 +745,13 @@ func (p *interp) getSpecial(index int) value {
 	case ast.V_NR:
 		return p.lineNum
 	case ast.V_RLENGTH:
-		return num(float64(p.matchLength))
+		return p.matchLength
 	case ast.V_RSTART:
-		return num(float64(p.matchStart))
+		return p.matchStart
 	case ast.V_FNR:
 		return p.fileLineNum
 	case ast.V_ARGC:
-		return num(float64(p.argc))
+		return p.argc
 	case ast.V_CONVFMT:
 		return str(p.convertFormat)
 	case ast.V_FILENAME:
@@ -815,9 +820,9 @@ func (p *interp) setSpecial(index int, v value) error {
 	case ast.V_NR:
 		p.lineNum = v
 	case ast.V_RLENGTH:
-		p.matchLength = int(v.num())
+		p.matchLength = v
 	case ast.V_RSTART:
-		p.matchStart = int(v.num())
+		p.matchStart = v
 	case ast.V_FNR:
 		p.fileLineNum = v
 	case ast.V_ARGC:
@@ -825,7 +830,7 @@ func (p *interp) setSpecial(index int, v value) error {
 		if argc > maxFieldIndex {
 			return newError("ARGC set too large: %d", argc)
 		}
-		p.argc = argc
+		p.argc = v
 	case ast.V_CONVFMT:
 		p.convertFormat = p.toString(v)
 	case ast.V_FILENAME:

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -325,7 +325,7 @@ BEGIN {
 	{`BEGIN { $0="1"; print ($0?1:0) }`, "", "1\n", "", ""},
 	{`BEGIN { print 0?1:0, 1?1:0, ""?1:0, "0"?1:0, "1"?1:0, x?1:0 }`, "", "0 1 0 1 1 0\n", "", ""},
 
-	// Built-in variables
+	// Built-in variables (special variables)
 	{`BEGIN { print ARGC; ARGC=42; print ARGC }  # !gawk`, "", "1\n42\n", "", ""}, // ARGC is properly tested in goawk_test.go
 	{`BEGIN { ARGC=1234567 }`, "", "", "ARGC set too large: 1234567", ""},
 	{`
@@ -429,6 +429,12 @@ BEGIN {
 	{`{ FS="X+"; print $1; print $2 }`, "aXXb c", "aXXb\nc\n", "", ""},
 	{`BEGIN { FS="," } { print $1; print $2 }`, "a,b c", "a\nb c\n", "", ""},
 	{`BEGIN { FS="X+" } { print $1; print $2 }`, "aXXb c", "a\nb c\n", "", ""},
+
+	// Handling of integer special variables
+	{`BEGIN { NR = "x"; print NR } { print NR }`, "a\nb\n", "x\n1\n2\n", "", ""},
+	{`BEGIN { NR = "3.14x"; print NR } { print NR }  # !awk !gawk`, "a\nb\n", "3.14x\n4.14\n5.14\n", "", ""},
+	{`BEGIN { FNR = "x"; print FNR } { print FNR }`, "a\nb\n", "x\n1\n2\n", "", ""},
+	{`BEGIN { FNR = "3.14x"; print FNR } { print FNR }  # !awk !gawk`, "a\nb\n", "3.14x\n1\n2\n", "", ""},
 
 	// Field expressions and assignment (and interaction with NF)
 	{`{ print NF; NF=1; $2="two"; print $0, NF }`, "\n", "0\n two 2\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -158,8 +158,7 @@ NR==3, NR==5 { print NR }
 	{`BEGIN { a[1]=1; a[2]=1; a[3]=1; for (k in a) { if (k==2) continue; s++ } print s }`, "", "2\n", "", ""},
 	{`function alen(a, k, n) { n=0; for (k in a) n++; return n }  BEGIN { a[1]=1; a[2]=1; print alen(a) }`, "", "2\n", "", ""},
 	{`BEGIN { a["x"]=1; for (SUBSEP in a) print SUBSEP, a[SUBSEP] }`, "", "x 1\n", "", ""},
-	// TODO: this doesn't work in GoAWK yet
-	// {`BEGIN { a["x"]=1; for (NR in a) print NR, a[NR] }`, "", "x 1\n", "", ""},
+	{`BEGIN { a["x"]=1; for (NR in a) print NR, a[NR] }`, "", "x 1\n", "", ""},
 	{`BEGIN { while (i<3) { i++; s++; break } print s }`, "", "1\n", "", ""},
 	{`BEGIN { while (i<3) { i++; if (i==2) continue; s++ } print s }`, "", "2\n", "", ""},
 	{`BEGIN { do { i++; s++; break } while (i<3); print s }`, "", "1\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -431,10 +431,18 @@ BEGIN {
 	{`BEGIN { FS="X+" } { print $1; print $2 }`, "aXXb c", "a\nb c\n", "", ""},
 
 	// Handling of integer special variables
+	{`BEGIN { print "NR", NR, "FNR", FNR, "RSTART", RSTART, "RLENGTH", RLENGTH, "ARGC>0", (ARGC>0) }`,
+		"", "NR 0 FNR 0 RSTART 0 RLENGTH 0 ARGC>0 1\n", "", ""},
 	{`BEGIN { NR = "x"; print NR } { print NR }`, "a\nb\n", "x\n1\n2\n", "", ""},
 	{`BEGIN { NR = "3.14x"; print NR } { print NR }  # !awk !gawk`, "a\nb\n", "3.14x\n4.14\n5.14\n", "", ""},
 	{`BEGIN { FNR = "x"; print FNR } { print FNR }`, "a\nb\n", "x\n1\n2\n", "", ""},
 	{`BEGIN { FNR = "3.14x"; print FNR } { print FNR }  # !awk !gawk`, "a\nb\n", "3.14x\n1\n2\n", "", ""},
+	{`BEGIN { RSTART = "x"; print RSTART; match("foo", /o/); print RSTART }`, "", "x\n2\n", "", ""},
+	{`BEGIN { RSTART = "3.14x"; print RSTART; match("foo", /o/); print RSTART }`, "", "3.14x\n2\n", "", ""},
+	{`BEGIN { RLENGTH = "x"; print RLENGTH; match("foo", /o+/); print RLENGTH }`, "", "x\n2\n", "", ""},
+	{`BEGIN { RLENGTH = "3.14x"; print RLENGTH; match("foo", /o+/); print RLENGTH }`, "", "3.14x\n2\n", "", ""},
+	{`BEGIN { ARGC = "x"; print ARGC }`, "", "x\n", "", ""},
+	{`BEGIN { ARGC = "3.14x"; print ARGC }`, "", "3.14x\n", "", ""},
 
 	// Field expressions and assignment (and interaction with NF)
 	{`{ print NF; NF=1; $2="two"; print $0, NF }`, "\n", "0\n two 2\n", "", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -431,8 +431,10 @@ BEGIN {
 	{`BEGIN { FS="X+" } { print $1; print $2 }`, "aXXb c", "a\nb c\n", "", ""},
 
 	// Handling of integer special variables
-	{`BEGIN { print "NR", NR, "FNR", FNR, "RSTART", RSTART, "RLENGTH", RLENGTH, "ARGC>0", (ARGC>0) }`,
-		"", "NR 0 FNR 0 RSTART 0 RLENGTH 0 ARGC>0 1\n", "", ""},
+	{`BEGIN { print "NF", NF, "NR", NR, "FNR", FNR, "RSTART", RSTART, "RLENGTH", RLENGTH, "ARGC>0", (ARGC>0) }`,
+		"", "NF 0 NR 0 FNR 0 RSTART 0 RLENGTH 0 ARGC>0 1\n", "", ""},
+	{`BEGIN { NF = "x"; print NF } { print NF }`, "a\na b c\n", "x\n1\n3\n", "", ""},
+	{`BEGIN { NF = "3.14x"; print NF } { print NF }`, "a\na b c\n", "3.14x\n1\n3\n", "", ""},
 	{`BEGIN { NR = "x"; print NR } { print NR }`, "a\nb\n", "x\n1\n2\n", "", ""},
 	{`BEGIN { NR = "3.14x"; print NR } { print NR }  # !awk !gawk`, "a\nb\n", "3.14x\n4.14\n5.14\n", "", ""},
 	{`BEGIN { FNR = "x"; print FNR } { print FNR }`, "a\nb\n", "x\n1\n2\n", "", ""},

--- a/interp/io.go
+++ b/interp/io.go
@@ -715,7 +715,7 @@ func (p *interp) ensureFields() {
 	for range p.fields {
 		p.fieldsIsTrueStr = append(p.fieldsIsTrueStr, false)
 	}
-	p.numFields = len(p.fields)
+	p.numFields = num(float64(len(p.fields)))
 }
 
 // Fetch next line (record) of input from current input file, opening

--- a/interp/io.go
+++ b/interp/io.go
@@ -621,7 +621,7 @@ func nextRune(b []byte) rune {
 // Setup for a new input file with given name (empty string if stdin)
 func (p *interp) setFile(filename string) {
 	p.filename = numStr(filename)
-	p.fileLineNum = 0
+	p.fileLineNum = num(0)
 	p.hadFiles = true
 }
 
@@ -804,8 +804,8 @@ func (p *interp) nextLine() (string, error) {
 	}
 
 	// Got a line (record) of input, return it
-	p.lineNum++
-	p.fileLineNum++
+	p.lineNum = num(p.lineNum.num() + 1)
+	p.fileLineNum = num(p.fileLineNum.num() + 1)
 	return p.scanner.Text(), nil
 }
 

--- a/interp/io.go
+++ b/interp/io.go
@@ -727,13 +727,13 @@ func (p *interp) nextLine() (string, error) {
 				// Previous input is file, close it
 				_ = prevInput.Close()
 			}
-			if p.filenameIndex >= p.argc && !p.hadFiles {
+			if p.filenameIndex >= int(p.argc.num()) && !p.hadFiles {
 				// Moved past number of ARGV args and haven't seen
 				// any files yet, use stdin
 				p.input = p.stdin
 				p.setFile("-")
 			} else {
-				if p.filenameIndex >= p.argc {
+				if p.filenameIndex >= int(p.argc.num()) {
 					// Done with ARGV args, all done with input
 					return "", io.EOF
 				}

--- a/interp/newexecute.go
+++ b/interp/newexecute.go
@@ -108,7 +108,7 @@ func (p *interp) resetCore() {
 	p.fileLineNum = num(0)
 	p.fields = nil
 	p.fieldsIsTrueStr = nil
-	p.numFields = 0
+	p.numFields = num(0)
 	p.haveFields = false
 
 	p.matchStart = num(0)

--- a/interp/newexecute.go
+++ b/interp/newexecute.go
@@ -111,6 +111,10 @@ func (p *interp) resetCore() {
 	p.numFields = 0
 	p.haveFields = false
 
+	p.matchStart = num(0)
+	p.matchLength = num(0)
+	p.argc = num(0)
+
 	p.exitStatus = 0
 }
 
@@ -140,8 +144,6 @@ func (p *interp) resetVars() {
 	p.outputFieldSep = " "
 	p.outputRecordSep = "\n"
 	p.subscriptSep = "\x1c"
-	p.matchLength = 0
-	p.matchStart = 0
 }
 
 // ResetVars resets this interpreter's variables, setting scalar variables to

--- a/interp/newexecute.go
+++ b/interp/newexecute.go
@@ -104,8 +104,8 @@ func (p *interp) resetCore() {
 	p.filename = null()
 	p.line = ""
 	p.lineIsTrueStr = false
-	p.lineNum = 0
-	p.fileLineNum = 0
+	p.lineNum = num(0)
+	p.fileLineNum = num(0)
 	p.fields = nil
 	p.fieldsIsTrueStr = nil
 	p.numFields = 0

--- a/interp/vm.go
+++ b/interp/vm.go
@@ -1034,16 +1034,16 @@ func (p *interp) callBuiltin(builtinOp compiler.BuiltinOp) error {
 		}
 		loc := re.FindStringIndex(s)
 		if loc == nil {
-			p.matchStart = 0
-			p.matchLength = -1
+			p.matchStart = num(0)
+			p.matchLength = num(-1)
 		} else if p.chars {
-			p.matchStart = utf8.RuneCountInString(s[:loc[0]]) + 1
-			p.matchLength = utf8.RuneCountInString(s[loc[0]:loc[1]])
+			p.matchStart = num(float64(utf8.RuneCountInString(s[:loc[0]]) + 1))
+			p.matchLength = num(float64(utf8.RuneCountInString(s[loc[0]:loc[1]])))
 		} else {
-			p.matchStart = loc[0] + 1
-			p.matchLength = loc[1] - loc[0]
+			p.matchStart = num(float64(loc[0] + 1))
+			p.matchLength = num(float64(loc[1] - loc[0]))
 		}
-		p.replaceTop(num(float64(p.matchStart)))
+		p.replaceTop(p.matchStart)
 
 	case compiler.BuiltinRand:
 		p.push(num(p.random.Float64()))


### PR DESCRIPTION
Currently if you do something like:

```
BEGIN { NR = "x"; print x }
```

GoAWK prints "0" instead "x" because we store integer special variables like NR and FNR as Go ints. To fix, we should store as AWK value types.
