### PR TITLE
Allow dynamically changing RS regex

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -856,7 +856,11 @@ func (p *interp) setSpecial(index int, v value) error {
 		p.recordSep = p.toString(v)
 		switch { // compare to interp.newScanner
 		case len(p.recordSep) <= 1:
-			// Simple cases use specialized splitters, not regex
+			// Simple cases use specialized splitters, not regex. However, we still update
+			// recordSepRegex in case an active regexSplitter is still using it.
+			sep := regexp.QuoteMeta(p.recordSep)
+			p.recordSepRegex = regexp.MustCompile(sep)
+			p.recordSepRegex.Longest() // other awks use leftmost-longest matching
 		case utf8.RuneCountInString(p.recordSep) == 1:
 			// Multi-byte unicode char falls back to regex splitter
 			sep := regexp.QuoteMeta(p.recordSep) // not strictly necessary as no multi-byte chars are regex meta chars

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -405,6 +405,28 @@ Record = record 2 and RT = [ BBBB ]
 Record = record 3 and RT = []
 `, "", ""},
 	{`BEGIN { RS=".." } { print $0 RT }  # !posix`, "foo bar bazz", "fo\no \nba\nr \nba\nzz\n", "", ""},
+	// Dynamically changing RS (regex) between records
+	{`BEGIN { RS="\\.+" } NR==2 { RS="x+" } { print NR, $0 }  # !posix !awk`, "1.2..3xxx4x5", "1 1\n2 2\n3 3\n4 4\n5 5\n", "", ""},
+	{`
+# Regression test for https://github.com/benhoyt/goawk/issues/143
+BEGIN { RS=".{9}" }
+NR==1 { $0=substr(RT,1,8); RS=substr(RT,9,1) }
+{ print $0 }
+# !posix !awk
+`, "UNA:+,? 'UNB+UNOC:3+4042805000102:14+4016001000655:14+201231:0206+EC33218279A++TL'UNH+1+MSCONS:D:04B:UN:2.3'BGM+7+EC33218279A-1+9'DTM+137:202012310206:203'RFF+Z13:13018'NAD+MS+4042805000102::9'NAD+MR+4016001000655::9'UNS+D'NAD+DP'LOC+172+DE00108108359V0000000000000088446'DTM+163:202012300000?+01:303",
+		"UNA:+,? \n" +
+			`UNB+UNOC:3+4042805000102:14+4016001000655:14+201231:0206+EC33218279A++TL
+UNH+1+MSCONS:D:04B:UN:2.3
+BGM+7+EC33218279A-1+9
+DTM+137:202012310206:203
+RFF+Z13:13018
+NAD+MS+4042805000102::9
+NAD+MR+4016001000655::9
+UNS+D
+NAD+DP
+LOC+172+DE00108108359V0000000000000088446
+DTM+163:202012300000?+01:303
+`, "", ""},
 	{`BEGIN { RT="foo"; print RT }`, "", "foo\n", "", ""},
 	{`
 BEGIN {

--- a/interp/io.go
+++ b/interp/io.go
@@ -266,7 +266,7 @@ func (p *interp) newScanner(input io.Reader, buffer []byte) *bufio.Scanner {
 		scanner.Split(splitter.scan)
 	case utf8.RuneCountInString(p.recordSep) >= 1:
 		// Multi-byte and single char but multi-byte RS use regex
-		splitter := regexSplitter{re: p.recordSepRegex, terminator: &p.recordTerminator}
+		splitter := regexSplitter{re: &p.recordSepRegex, terminator: &p.recordTerminator}
 		scanner.Split(splitter.scan)
 	}
 	scanner.Buffer(buffer, maxRecordLength)
@@ -381,9 +381,11 @@ func (s byteSplitter) scan(data []byte, atEOF bool) (advance int, token []byte, 
 	return 0, nil, nil
 }
 
-// Splitter that splits records on the given regular expression
+// Splitter that splits records on the given regular expression.
 type regexSplitter struct {
-	re         *regexp.Regexp
+	// Use a pointer to a *Regexp (&p.recordSepRegex) so that the splitter always reads
+	// the current regex, allowing dynamic changes to RS during execution.
+	re         **regexp.Regexp
 	terminator *string
 }
 
@@ -391,7 +393,7 @@ func (s regexSplitter) scan(data []byte, atEOF bool) (advance int, token []byte,
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
 	}
-	loc := s.re.FindIndex(data)
+	loc := (*s.re).FindIndex(data)
 	// Note: for a regex such as "()", loc[0]==loc[1]. Gawk behavior for this
 	// case is to match the entire input.
 	if loc != nil && loc[0] != loc[1] {


### PR DESCRIPTION
This was easier than I thought it would be! (Thanks GitHub Copilot and Claude Opus 4.6.)

Two changes were required:

- Updating regexSplitter to take a pointer to a *Regexp (specifically, &p.recordSepRegex) so that the regexSplitter always reads the current RS regex.
- Set p.recordSepRegex in the len(p.recordSep)<=1 case, so that even if the regex isn't normally used, we still update recordSepRegex in case an active regexSplitter scanner is still using it.

Fixes #143