### PR TITLE
Fix interp tests on Ubuntu 26.04

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1740,8 +1740,8 @@ func TestSystemCommandNotFound(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	got := outBuf.buffer.String()
-	if !strings.Contains(got, "foobar3982") || !strings.Contains(got, "not found") {
-		t.Fatalf(`expected output to contain "foobar3982" and "not found", got %q`, got)
+	if !strings.Contains(got, "foobar3982") || !(strings.Contains(got, "not found") || strings.Contains(got, "denied")) {
+		t.Fatalf(`expected output to contain "foobar3982" and "not found" or "denied", got %q`, got)
 	}
 }
 


### PR DESCRIPTION
Error message is different on Ubuntu 26.04, update it. On 26.04 we get "Permission denied":

goawk 'BEGIN { print system("foobar3982") }'
/bin/sh: 1: foobar3982: Permission denied
127