### PR TITLE
Replace Config.OpenFile with more general fs.FS-based approach

### DIFF
--- a/goawk_test.go
+++ b/goawk_test.go
@@ -113,7 +113,7 @@ func TestAWK(t *testing.T) {
 				expected = sortedLines(expected)
 			}
 			if writeAWK {
-				err := os.WriteFile(outputPath, expected, 0644)
+				err := os.WriteFile(outputPath, expected, 0o644)
 				if err != nil {
 					t.Fatalf("error writing awk output: %v", err)
 				}
@@ -139,7 +139,7 @@ func TestAWK(t *testing.T) {
 				output = sortedLines(output)
 			}
 			if writeGoAWK {
-				err := os.WriteFile(outputPath, output, 0644)
+				err := os.WriteFile(outputPath, output, 0o644)
 				if err != nil {
 					t.Fatalf("error writing goawk output: %v", err)
 				}

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -78,7 +78,7 @@ func (cover *Cover) WriteProfile(path string, data map[string]any) (err error) {
 
 	var f *os.File
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (cover *Cover) WriteProfile(path string, data map[string]any) (err error) {
 			isNewFile = false
 			fileOpt = os.O_APPEND
 		}
-		f, err = os.OpenFile(path, os.O_WRONLY|fileOpt, 0644)
+		f, err = os.OpenFile(path, os.O_WRONLY|fileOpt, 0o644)
 		if err != nil {
 			return err
 		}

--- a/interp/filesystem_root_test.go
+++ b/interp/filesystem_root_test.go
@@ -65,8 +65,11 @@ func TestFileSystemRoot(t *testing.T) {
 		return output, err
 	}
 
-	t.Run("success", func(t *testing.T) {
-		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" > "output.txt" }`)
+	t.Run("successful write", func(t *testing.T) {
+		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" >"output.txt" }`)
+		if err != nil {
+			t.Fatalf("runProgram error: %v", err)
+		}
 		if output.Len() != 0 {
 			t.Fatalf("expected empty stdout, got %q", output.String())
 		}
@@ -81,8 +84,27 @@ func TestFileSystemRoot(t *testing.T) {
 		}
 	})
 
+	t.Run("successful append", func(t *testing.T) {
+		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" >>"output.txt" }`)
+		if err != nil {
+			t.Fatalf("runProgram error: %v", err)
+		}
+		if output.Len() != 0 {
+			t.Fatalf("expected empty stdout, got %q", output.String())
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "output.txt"))
+		if err != nil {
+			t.Fatalf("error reading file in root: %v", err)
+		}
+		const expected = "Hello, GoAWK!\nHello, GoAWK!\n"
+		normalized := normalizeNewlines(string(data))
+		if normalized != expected {
+			t.Fatalf("expected file content %q, got %q", expected, normalized)
+		}
+	})
+
 	t.Run("path traversal", func(t *testing.T) {
-		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" > "../../etc/passwd" }`)
+		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" >"../../etc/passwd" }`)
 		const expectedErr = "path escapes from parent"
 		if err == nil {
 			t.Fatalf("expected error contains %q, got <nil>", expectedErr)

--- a/interp/filesystem_root_test.go
+++ b/interp/filesystem_root_test.go
@@ -5,6 +5,7 @@ package interp_test
 import (
 	"bytes"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,25 @@ import (
 	"github.com/benhoyt/goawk/parser"
 )
 
-func TestOpenFileRoot(t *testing.T) {
+// rootFS adapts an [*os.Root] into an [fs.FS] that also implements
+// [interp.WriteFS], confining all access to the root tree.
+type rootFS struct {
+	Root *os.Root
+}
+
+func (r rootFS) Open(name string) (fs.File, error) {
+	return r.Root.Open(name)
+}
+
+func (r rootFS) Create(name string) (io.WriteCloser, error) {
+	return r.Root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+}
+
+func (r rootFS) Append(name string) (io.WriteCloser, error) {
+	return r.Root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+}
+
+func TestFileSystemRoot(t *testing.T) {
 	dir := t.TempDir()
 	root, err := os.OpenRoot(dir)
 	if err != nil {
@@ -34,10 +53,10 @@ func TestOpenFileRoot(t *testing.T) {
 		}
 		output = new(bytes.Buffer)
 		config := interp.Config{
-			Stdin:    strings.NewReader(""),
-			Output:   output,
-			Error:    io.Discard,
-			OpenFile: root.OpenFile,
+			Stdin:      strings.NewReader(""),
+			Output:     output,
+			Error:      io.Discard,
+			FileSystem: rootFS{Root: root},
 		}
 		status, err := interp.ExecProgram(prog, &config)
 		if status != 0 {

--- a/interp/filesystem_root_test.go
+++ b/interp/filesystem_root_test.go
@@ -26,11 +26,11 @@ func (r rootFS) Open(name string) (fs.File, error) {
 }
 
 func (r rootFS) Create(name string) (io.WriteCloser, error) {
-	return r.Root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	return r.Root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 }
 
 func (r rootFS) Append(name string) (io.WriteCloser, error) {
-	return r.Root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	return r.Root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 }
 
 func TestFileSystemRoot(t *testing.T) {
@@ -83,7 +83,7 @@ func TestFileSystemRoot(t *testing.T) {
 
 	t.Run("path traversal", func(t *testing.T) {
 		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" > "../../etc/passwd" }`)
-		const expectedErr = `path escapes from parent`
+		const expectedErr = "path escapes from parent"
 		if err == nil {
 			t.Fatalf("expected error contains %q, got <nil>", expectedErr)
 		} else if !strings.Contains(err.Error(), expectedErr) {

--- a/interp/filesystem_root_test.go
+++ b/interp/filesystem_root_test.go
@@ -85,18 +85,22 @@ func TestFileSystemRoot(t *testing.T) {
 	})
 
 	t.Run("successful append", func(t *testing.T) {
-		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" >>"output.txt" }`)
+		err := os.WriteFile(filepath.Join(dir, "append.txt"), []byte("existing line\n"), 0o644)
+		if err != nil {
+			t.Fatalf("error writing file in root: %v", err)
+		}
+		output, err := runProgram(`BEGIN { print "Hello, GoAWK!" >>"append.txt" }`)
 		if err != nil {
 			t.Fatalf("runProgram error: %v", err)
 		}
 		if output.Len() != 0 {
 			t.Fatalf("expected empty stdout, got %q", output.String())
 		}
-		data, err := os.ReadFile(filepath.Join(dir, "output.txt"))
+		data, err := os.ReadFile(filepath.Join(dir, "append.txt"))
 		if err != nil {
 			t.Fatalf("error reading file in root: %v", err)
 		}
-		const expected = "Hello, GoAWK!\nHello, GoAWK!\n"
+		const expected = "existing line\nHello, GoAWK!\n"
 		normalized := normalizeNewlines(string(data))
 		if normalized != expected {
 			t.Fatalf("expected file content %q, got %q", expected, normalized)

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -332,7 +332,8 @@ type Config struct {
 	// The default is to use the operating system's regular filesystem, relative
 	// to the working directory. Note that the default isn't strictly a valid
 	// fs.FS, as it allows absolute paths and paths with "." or ".." in them,
-	// unlike fs.ValidPath.
+	// unlike fs.ValidPath. The filenames passed to the FileSystem methods come
+	// directly from the user without validation.
 	//
 	// A filesystem must return an error wrapping [fs.ErrNotExist] for missing
 	// files: GoAWK treats that as getline returning -1 rather than a fatal error.

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"math/rand"
 	"os"
@@ -87,7 +88,7 @@ type interp struct {
 	csvOutput     *bufio.Writer
 	noArgVars     bool
 	splitBuffer   []byte
-	openFile      OpenFileFunc
+	fs            fs.FS
 
 	// Scalars, arrays, and function state
 	globals       []value
@@ -323,20 +324,39 @@ type Config struct {
 	// and CRLF translation on Windows.
 	NewlineOutput NewlineMode
 
-	// OpenFile specifies the function used to open and create files. Set this
-	// to an [os.Root.OpenFile] method to limit file access to within a root
-	// tree, or to a custom function (for example, to limit the interpreter to
-	// read-only file access). The default is [os.OpenFile].
+	// FileSystem specifies the filesystem used for file-based I/O: files named
+	// on the command line or via ARGV, getline < "f" reads, and print > "f"
+	// / print >> "f" writes. It may be any [fs.FS] for read-only programs; to
+	// allow output redirection it must also implement [WriteFS]. The default
+	// (nil) uses the operating system's filesystem relative to the process
+	// working directory.
 	//
-	// A custom OpenFile function must return an error that satisfies
-	// errors.Is(err, fs.ErrNotExist) for files that don't exist when flag is
-	// os.O_RDONLY.
-	OpenFile OpenFileFunc
+	// A read filesystem must return an error wrapping [fs.ErrNotExist] for
+	// missing files; GoAWK treats that as getline returning -1 rather than a
+	// fatal error.
+	FileSystem fs.FS
 }
 
-// OpenFileFunc is the type used for setting [Config.OpenFile], and is the type
-// of [os.OpenFile].
-type OpenFileFunc func(name string, flag int, perm os.FileMode) (*os.File, error)
+// WriteFS is an optional capability of an [fs.FS] assigned to
+// [Config.FileSystem]. If the filesystem implements WriteFS, output
+// redirection (print > "f" and print >> "f") creates and appends files through
+// it; if it does not, output redirection fails with a "read-only filesystem"
+// error.
+//
+// Create is used for AWK's ">" redirection (create or truncate the file) and
+// Append is used for ">>" (create the file if needed and append to it).
+// Implementations should return errors wrapping [fs.ErrNotExist] for missing
+// files where appropriate, consistent with [fs.FS.Open].
+type WriteFS interface {
+	fs.FS
+
+	// Create creates or truncates the named file and returns it for writing.
+	Create(name string) (io.WriteCloser, error)
+
+	// Append opens the named file for appending, creating it if it doesn't
+	// exist. Subsequent writes go to the end of the file.
+	Append(name string) (io.WriteCloser, error)
+}
 
 // IOMode specifies the input parsing or print output mode.
 type IOMode int
@@ -493,10 +513,10 @@ func (p *interp) setExecuteConfig(config *Config) error {
 			return newError("output mode configuration not valid in default output mode")
 		}
 	}
-	if config.OpenFile == nil {
-		p.openFile = os.OpenFile
+	if config.FileSystem == nil {
+		p.fs = osFS{}
 	} else {
-		p.openFile = config.OpenFile
+		p.fs = config.FileSystem
 	}
 
 	// Set up ARGV and other variables from config

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -88,7 +88,7 @@ type interp struct {
 	csvOutput     *bufio.Writer
 	noArgVars     bool
 	splitBuffer   []byte
-	fs            fs.FS
+	fileSystem    fs.FS
 
 	// Scalars, arrays, and function state
 	globals       []value
@@ -325,36 +325,30 @@ type Config struct {
 	NewlineOutput NewlineMode
 
 	// FileSystem specifies the filesystem used for file-based I/O: files named
-	// on the command line or via ARGV, getline < "f" reads, and print > "f"
-	// / print >> "f" writes. It may be any [fs.FS] for read-only programs; to
-	// allow output redirection it must also implement [WriteFS]. The default
-	// (nil) uses the operating system's filesystem relative to the process
-	// working directory.
+	// on the command line or via ARGV, getline <"f" reads, and print >"f"
+	// or print >>"f" writes. It may be any [fs.FS] for read-only access; to
+	// allow output redirection it must also implement [WriteFS].
 	//
-	// A read filesystem must return an error wrapping [fs.ErrNotExist] for
-	// missing files; GoAWK treats that as getline returning -1 rather than a
-	// fatal error.
+	// The default is to use the operating system's regular filesystem, relative
+	// to the working directory. Note that the default isn't strictly a valid
+	// fs.FS, as it allows absolute paths and paths with "." or ".." in them,
+	// unlike fs.ValidPath.
+	//
+	// A filesystem must return an error wrapping [fs.ErrNotExist] for missing
+	// files: GoAWK treats that as getline returning -1 rather than a fatal error.
 	FileSystem fs.FS
 }
 
-// WriteFS is an optional capability of an [fs.FS] assigned to
-// [Config.FileSystem]. If the filesystem implements WriteFS, output
-// redirection (print > "f" and print >> "f") creates and appends files through
-// it; if it does not, output redirection fails with a "read-only filesystem"
-// error.
-//
-// Create is used for AWK's ">" redirection (create or truncate the file) and
-// Append is used for ">>" (create the file if needed and append to it).
-// Implementations should return errors wrapping [fs.ErrNotExist] for missing
-// files where appropriate, consistent with [fs.FS.Open].
+// WriteFS is an interface extension for an [fs.FS] assigned to [Config.FileSystem].
+// If the filesystem implements WriteFS, output redirection is allowed: print >"f"
+// uses Create and print >>"f" uses Append.
 type WriteFS interface {
 	fs.FS
 
 	// Create creates or truncates the named file and returns it for writing.
 	Create(name string) (io.WriteCloser, error)
 
-	// Append opens the named file for appending, creating it if it doesn't
-	// exist. Subsequent writes go to the end of the file.
+	// Append opens the named file for appending, creating it if it doesn't exist.
 	Append(name string) (io.WriteCloser, error)
 }
 
@@ -514,9 +508,9 @@ func (p *interp) setExecuteConfig(config *Config) error {
 		}
 	}
 	if config.FileSystem == nil {
-		p.fs = osFS{}
+		p.fileSystem = osFS{}
 	} else {
-		p.fs = config.FileSystem
+		p.fileSystem = config.FileSystem
 	}
 
 	// Set up ARGV and other variables from config

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2259,6 +2259,19 @@ func TestFileSystemReadOnly(t *testing.T) {
 		}
 	})
 
+	t.Run("cannot append", func(t *testing.T) {
+		output, err := runProgram(`BEGIN { print "foo" >>"output.txt" }`)
+		const expectedErr = "filesystem is read-only"
+		if err == nil {
+			t.Fatalf("expected error contains %q, got <nil>", expectedErr)
+		} else if !strings.Contains(err.Error(), expectedErr) {
+			t.Fatalf("expected error contains %q, got %q", expectedErr, err.Error())
+		}
+		if output.Len() != 0 {
+			t.Fatalf("expected empty stdout, got %q", output.String())
+		}
+	})
+
 	t.Run("can read", func(t *testing.T) {
 		output, err := runProgram(`BEGIN { getline <"file.txt"; print $0 }`)
 		if err != nil {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/fstest"
 
 	"github.com/benhoyt/goawk/interp"
 	"github.com/benhoyt/goawk/parser"
@@ -2221,12 +2222,11 @@ func TestCSVMultiRead(t *testing.T) {
 	}
 }
 
-func TestOpenFileCustom(t *testing.T) {
-	openFile := func(name string, flags int, mode os.FileMode) (*os.File, error) {
-		if flags&os.O_RDWR != 0 || flags&os.O_WRONLY != 0 {
-			return nil, fmt.Errorf("can't open %s for writing: read only filesystem", name)
-		}
-		return os.OpenFile(name, flags, mode)
+func TestFileSystemReadOnly(t *testing.T) {
+	// A read-only fs.FS (no WriteFS capability): output redirection must fail,
+	// reads work, and missing files report fs.ErrNotExist (getline returns -1).
+	fsys := fstest.MapFS{
+		"openfile.txt": &fstest.MapFile{Data: []byte("OpenFile read test\n")},
 	}
 
 	runProgram := func(source string) (output *bytes.Buffer, err error) {
@@ -2236,10 +2236,10 @@ func TestOpenFileCustom(t *testing.T) {
 		}
 		output = new(bytes.Buffer)
 		config := interp.Config{
-			Stdin:    strings.NewReader(""),
-			Output:   output,
-			Error:    io.Discard,
-			OpenFile: openFile,
+			Stdin:      strings.NewReader(""),
+			Output:     output,
+			Error:      io.Discard,
+			FileSystem: fsys,
 		}
 		status, err := interp.ExecProgram(prog, &config)
 		if status != 0 {
@@ -2250,7 +2250,7 @@ func TestOpenFileCustom(t *testing.T) {
 
 	t.Run("cannot write", func(t *testing.T) {
 		output, err := runProgram(`BEGIN { print "foo" > "output.txt" }`)
-		const expectedErr = `can't open output.txt for writing: read only filesystem`
+		const expectedErr = `filesystem is read-only`
 		if err == nil {
 			t.Fatalf("expected error contains %q, got <nil>", expectedErr)
 		} else if !strings.Contains(err.Error(), expectedErr) {
@@ -2262,7 +2262,7 @@ func TestOpenFileCustom(t *testing.T) {
 	})
 
 	t.Run("can read", func(t *testing.T) {
-		output, err := runProgram(`BEGIN { getline <"./testdata/openfile.txt"; print $0 }`)
+		output, err := runProgram(`BEGIN { getline <"openfile.txt"; print $0 }`)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2223,10 +2223,8 @@ func TestCSVMultiRead(t *testing.T) {
 }
 
 func TestFileSystemReadOnly(t *testing.T) {
-	// A read-only fs.FS (no WriteFS capability): output redirection must fail,
-	// reads work, and missing files report fs.ErrNotExist (getline returns -1).
 	fsys := fstest.MapFS{
-		"openfile.txt": &fstest.MapFile{Data: []byte("OpenFile read test\n")},
+		"file.txt": &fstest.MapFile{Data: []byte("read test\n")},
 	}
 
 	runProgram := func(source string) (output *bytes.Buffer, err error) {
@@ -2249,8 +2247,8 @@ func TestFileSystemReadOnly(t *testing.T) {
 	}
 
 	t.Run("cannot write", func(t *testing.T) {
-		output, err := runProgram(`BEGIN { print "foo" > "output.txt" }`)
-		const expectedErr = `filesystem is read-only`
+		output, err := runProgram(`BEGIN { print "foo" >"output.txt" }`)
+		const expectedErr = "filesystem is read-only"
 		if err == nil {
 			t.Fatalf("expected error contains %q, got <nil>", expectedErr)
 		} else if !strings.Contains(err.Error(), expectedErr) {
@@ -2262,11 +2260,11 @@ func TestFileSystemReadOnly(t *testing.T) {
 	})
 
 	t.Run("can read", func(t *testing.T) {
-		output, err := runProgram(`BEGIN { getline <"openfile.txt"; print $0 }`)
+		output, err := runProgram(`BEGIN { getline <"file.txt"; print $0 }`)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		const expected = "OpenFile read test\n"
+		const expected = "read test\n"
 		normalized := normalizeNewlines(output.String())
 		if normalized != expected {
 			t.Fatalf("expected output %q, got %q", expected, normalized)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"reflect"
@@ -2295,6 +2296,118 @@ func TestFileSystemReadOnly(t *testing.T) {
 			t.Fatalf("expected output %q, got %q", expected, normalized)
 		}
 	})
+}
+
+// memFS is a simple in-memory filesystem that implements [interp.WriteFS].
+type memFS struct {
+	fstest.MapFS
+}
+
+func (m memFS) Create(name string) (io.WriteCloser, error) {
+	file := &fstest.MapFile{}
+	m.MapFS[name] = file
+	return memFile{file}, nil
+}
+
+func (m memFS) Append(name string) (io.WriteCloser, error) {
+	file, ok := m.MapFS[name]
+	if !ok {
+		file = &fstest.MapFile{}
+		m.MapFS[name] = file
+	}
+	return memFile{file}, nil
+}
+
+type memFile struct {
+	file *fstest.MapFile
+}
+
+func (f memFile) Write(buf []byte) (int, error) {
+	f.file.Data = append(f.file.Data, buf...)
+	return len(buf), nil
+}
+
+func (f memFile) Close() error {
+	return nil
+}
+
+func TestFileSystemWrite(t *testing.T) {
+	fsys := memFS{fstest.MapFS{}}
+	source := `BEGIN {
+		print "one" >"out.txt"     # Create makes a new file
+		close("out.txt")
+		print "two" >>"out.txt"    # Append adds to the existing file
+		close("out.txt")
+		print "x" >"trunc.txt"
+		close("trunc.txt")
+		print "y" >"trunc.txt"     # Create truncates the existing file
+	}`
+	prog, err := parser.ParseProgram([]byte(source), nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+	config := interp.Config{
+		Stdin:      strings.NewReader(""),
+		Output:     io.Discard,
+		Error:      io.Discard,
+		FileSystem: fsys,
+	}
+	status, err := interp.ExecProgram(prog, &config)
+	if err != nil {
+		t.Fatalf("error executing: %v", err)
+	}
+	if status != 0 {
+		t.Fatalf("expected status 0, got %d", status)
+	}
+
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"out.txt", "one\ntwo\n"},
+		{"trunc.txt", "y\n"},
+	}
+	for _, test := range tests {
+		data, err := fs.ReadFile(fsys, test.name)
+		if err != nil {
+			t.Fatalf("error reading %s: %v", test.name, err)
+		}
+		normalized := normalizeNewlines(string(data))
+		if normalized != test.expected {
+			t.Fatalf("expected %s content %q, got %q", test.name, test.expected, normalized)
+		}
+	}
+}
+
+func TestFileSystemArgs(t *testing.T) {
+	fsys := fstest.MapFS{
+		"one.txt": &fstest.MapFile{Data: []byte("first\nsecond\n")},
+		"two.txt": &fstest.MapFile{Data: []byte("third\n")},
+	}
+	prog, err := parser.ParseProgram([]byte(`{ print FILENAME, FNR, $0 }`), nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+	output := new(bytes.Buffer)
+	config := interp.Config{
+		Stdin:      strings.NewReader(""),
+		Output:     output,
+		Error:      io.Discard,
+		Args:       []string{"one.txt", "two.txt"},
+		FileSystem: fsys,
+	}
+	status, err := interp.ExecProgram(prog, &config)
+	if err != nil {
+		t.Fatalf("error executing: %v", err)
+	}
+	if status != 0 {
+		t.Fatalf("expected status 0, got %d", status)
+	}
+	expected := "one.txt 1 first\none.txt 2 second\ntwo.txt 1 third\n"
+	normalized := normalizeNewlines(output.String())
+	if normalized != expected {
+		t.Fatalf("expected output %q, got %q", expected, normalized)
+	}
 }
 
 type sliceReader struct {

--- a/interp/io.go
+++ b/interp/io.go
@@ -23,6 +23,9 @@ import (
 
 // osFS is the default filesystem, backed by the operating system's filesystem
 // relative to the process working directory. It implements WriteFS.
+//
+// This isn't a strictly valid fs.FS implementation, as it allows absolute paths
+// and paths with "." and ".." in them (these don't satisfy fs.ValidPath).
 type osFS struct{}
 
 func (osFS) Open(name string) (fs.File, error) {
@@ -30,11 +33,11 @@ func (osFS) Open(name string) (fs.File, error) {
 }
 
 func (osFS) Create(name string) (io.WriteCloser, error) {
-	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 }
 
 func (osFS) Append(name string) (io.WriteCloser, error) {
-	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 }
 
 // Print a line of output followed by a newline
@@ -146,7 +149,7 @@ func (p *interp) getOutputStream(redirect lexer.Token, destValue value) (io.Writ
 			return p.output, nil
 		}
 
-		wfs, ok := p.fs.(WriteFS)
+		wfs, ok := p.fileSystem.(WriteFS)
 		if !ok {
 			return nil, newError("can't write to file %q: filesystem is read-only", name)
 		}
@@ -224,7 +227,7 @@ func (p *interp) getInputScannerFile(name string) (*bufio.Scanner, error) {
 	if p.noFileReads {
 		return nil, newError("can't read from file due to NoFileReads")
 	}
-	f, err := p.fs.Open(name)
+	f, err := p.fileSystem.Open(name)
 	if err != nil {
 		return nil, err // fs.ErrNotExist is handled by caller (getline returns -1)
 	}
@@ -800,7 +803,7 @@ func (p *interp) nextLine() (string, error) {
 					if p.noFileReads {
 						return "", newError("can't read from file due to NoFileReads")
 					}
-					input, err := p.fs.Open(filename)
+					input, err := p.fileSystem.Open(filename)
 					if err != nil {
 						return "", err
 					}

--- a/interp/io.go
+++ b/interp/io.go
@@ -8,6 +8,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"regexp"
@@ -19,6 +20,22 @@ import (
 	"github.com/benhoyt/goawk/internal/resolver"
 	"github.com/benhoyt/goawk/lexer"
 )
+
+// osFS is the default filesystem, backed by the operating system's filesystem
+// relative to the process working directory. It implements WriteFS.
+type osFS struct{}
+
+func (osFS) Open(name string) (fs.File, error) {
+	return os.Open(name)
+}
+
+func (osFS) Create(name string) (io.WriteCloser, error) {
+	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+}
+
+func (osFS) Append(name string) (io.WriteCloser, error) {
+	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+}
 
 // Print a line of output followed by a newline
 func (p *interp) printLine(writer io.Writer, line string) error {
@@ -129,13 +146,17 @@ func (p *interp) getOutputStream(redirect lexer.Token, destValue value) (io.Writ
 			return p.output, nil
 		}
 
-		flags := os.O_CREATE | os.O_WRONLY
-		if redirect == lexer.GREATER {
-			flags |= os.O_TRUNC
-		} else {
-			flags |= os.O_APPEND
+		wfs, ok := p.fs.(WriteFS)
+		if !ok {
+			return nil, newError("can't write to file %q: filesystem is read-only", name)
 		}
-		f, err := p.openFile(name, flags, 0644)
+		var f io.WriteCloser
+		var err error
+		if redirect == lexer.GREATER {
+			f, err = wfs.Create(name)
+		} else {
+			f, err = wfs.Append(name)
+		}
 		if err != nil {
 			return nil, newError("output redirection error: %s", err)
 		}
@@ -203,7 +224,7 @@ func (p *interp) getInputScannerFile(name string) (*bufio.Scanner, error) {
 	if p.noFileReads {
 		return nil, newError("can't read from file due to NoFileReads")
 	}
-	f, err := p.openFile(name, os.O_RDONLY, 0)
+	f, err := p.fs.Open(name)
 	if err != nil {
 		return nil, err // fs.ErrNotExist is handled by caller (getline returns -1)
 	}
@@ -779,7 +800,7 @@ func (p *interp) nextLine() (string, error) {
 					if p.noFileReads {
 						return "", newError("can't read from file due to NoFileReads")
 					}
-					input, err := p.openFile(filename, os.O_RDONLY, 0)
+					input, err := p.fs.Open(filename)
 					if err != nil {
 						return "", err
 					}

--- a/interp/testdata/openfile.txt
+++ b/interp/testdata/openfile.txt
@@ -1,1 +1,0 @@
-OpenFile read test


### PR DESCRIPTION
In #294 we added Config.OpenFile, but it returned a concrete *os.File, which makes it a lot less flexible than it needs to be. As this version hasn't been released yet, let's see if we can improve that.

I'd like to fit in with io/fs.FS if possible, so that's what I've tried to do: if you provide a bare fs.FS for Config.FileSystem it allows read-only file access. If the type also implements WriteFS (adding Create and Append methods) it allow read and write access.

This is a breaking change, but (thankfully) I haven't released the Config.OpenFile support in a versioned release yet, so I'm okay with this.