### PR TITLE
Fix CONVFMT and OFMT for non-float types

### DIFF
--- a/interp/functions.go
+++ b/interp/functions.go
@@ -420,13 +420,51 @@ func (p *interp) parseFmtTypes(s string) (format string, types []byte, err error
 	return format, types, nil
 }
 
-// Convert a CONVFMT or OFMT value to its equivalent Go format string.
-func (p *interp) goFloatFormat(format string) string {
+// numFormat is a parsed CONVFMT or OFMT value. Parsing it when the special
+// variable is set (rather than on every conversion) keeps number-to-string
+// conversion fast in the usual case.
+type numFormat struct {
+	format   string // format as set by the AWK program (what getSpecial returns)
+	goFormat string // equivalent Go format string (only used if isFloat)
+	isFloat  bool   // format is a single float conversion, so value.str can do it
+	hasStr   bool   // format includes an %s conversion (see interp.numToString)
+}
+
+// The default CONVFMT and OFMT, also used as the fallback for a format that
+// value.str can't apply directly.
+var defaultNumFormat = numFormat{format: "%.6g", goFormat: "%.6g", isFloat: true}
+
+// Parse a CONVFMT or OFMT value for later use by interp.formatNum.
+func (p *interp) parseNumFormat(format string) numFormat {
 	goFormat, types, err := p.parseFmtTypes(format)
-	if err != nil || len(types) != 1 || types[0] != 'f' {
-		return format
+	if err == nil && len(types) == 1 && types[0] == 'f' {
+		// A single floating-point conversion: the normal case, which
+		// value.str can format directly.
+		return numFormat{format: format, goFormat: goFormat, isFloat: true}
 	}
-	return goFormat
+	// Anything else (no conversions at all, or one that needs the number
+	// converted to an integer or character, such as %d or %c) goes via sprintf.
+	f := numFormat{format: format, goFormat: defaultNumFormat.goFormat}
+	for _, t := range types {
+		if t == 's' {
+			f.hasStr = true
+		}
+	}
+	return f
+}
+
+// Format a number using a CONVFMT or OFMT value that value.str can't apply
+// directly, such as "%d" or "%c". Only called for values that actually need
+// formatting (see needsNumFormat).
+func (p *interp) formatNum(f numFormat, v value) string {
+	s, err := p.sprintf(f.format, []value{v})
+	if err != nil {
+		// Format is invalid or needs more than one argument. Other AWKs
+		// raise an error here; we use the format as a literal string, which
+		// is what Gawk does for an invalid conversion.
+		return f.format
+	}
+	return s
 }
 
 // Guts of sprintf() function (also used by "printf" statement)

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -118,10 +118,8 @@ type interp struct {
 
 	// Built-in variables
 	argc             value
-	convertFormat    string
-	convertFormatGo  string // Go fmt.Sprintf equivalent of convertFormat
-	outputFormat     string
-	outputFormatGo   string // Go fmt.Sprintf equivalent of outputFormat
+	convertFormat    numFormat
+	outputFormat     numFormat
 	fieldSep         string
 	fieldSepRegex    *regexp.Regexp
 	recordSep        string
@@ -444,10 +442,8 @@ func newInterp(program *parser.Program) *interp {
 	p.randSeed = 1.0
 	seed := math.Float64bits(p.randSeed)
 	p.random = rand.New(rand.NewSource(int64(seed)))
-	p.convertFormat = "%.6g"
-	p.convertFormatGo = "%.6g"
-	p.outputFormat = "%.6g"
-	p.outputFormatGo = "%.6g"
+	p.convertFormat = defaultNumFormat
+	p.outputFormat = defaultNumFormat
 	p.fieldSep = " "
 	p.savedFieldSep = " "
 	p.recordSep = "\n"
@@ -793,13 +789,13 @@ func (p *interp) getSpecial(index int) value {
 	case ast.V_ARGC:
 		return p.argc
 	case ast.V_CONVFMT:
-		return str(p.convertFormat)
+		return str(p.convertFormat.format)
 	case ast.V_FILENAME:
 		return p.filename
 	case ast.V_FS:
 		return str(p.fieldSep)
 	case ast.V_OFMT:
-		return str(p.outputFormat)
+		return str(p.outputFormat.format)
 	case ast.V_OFS:
 		return str(p.outputFieldSep)
 	case ast.V_ORS:
@@ -872,8 +868,7 @@ func (p *interp) setSpecial(index int, v value) error {
 		}
 		p.argc = v
 	case ast.V_CONVFMT:
-		p.convertFormat = p.toString(v)
-		p.convertFormatGo = p.goFloatFormat(p.convertFormat)
+		p.convertFormat = p.parseNumFormat(p.toString(v))
 	case ast.V_FILENAME:
 		p.filename = v
 	case ast.V_FS:
@@ -887,8 +882,10 @@ func (p *interp) setSpecial(index int, v value) error {
 			p.fieldSepRegex = re
 		}
 	case ast.V_OFMT:
-		p.outputFormat = p.toString(v)
-		p.outputFormatGo = p.goFloatFormat(p.outputFormat)
+		p.outputFormat = p.parseNumFormat(p.toString(v))
+		// An %s conversion is fine in OFMT (it converts the number using
+		// CONVFMT); hasStr only guards CONVFMT referring back to itself.
+		p.outputFormat.hasStr = false
 	case ast.V_OFS:
 		p.outputFieldSep = p.toString(v)
 	case ast.V_ORS:
@@ -1061,7 +1058,36 @@ func (p *interp) joinFields(fields []string) string {
 
 // Convert value to string using current CONVFMT
 func (p *interp) toString(v value) string {
-	return v.str(p.convertFormatGo)
+	if v.typ != typeNum {
+		// For typeStr and typeNumStr we already have the string, for
+		// typeNull v.s == "".
+		return v.s
+	}
+	return p.numToString(v.n, p.convertFormat)
+}
+
+// Convert value to string using current OFMT (used by "print")
+func (p *interp) toOutputString(v value) string {
+	if v.typ != typeNum {
+		return v.s
+	}
+	return p.numToString(v.n, p.outputFormat)
+}
+
+// Convert a number to a string using the given CONVFMT or OFMT value.
+func (p *interp) numToString(n float64, f numFormat) string {
+	if !f.isFloat && needsNumFormat(n) {
+		if f.hasStr {
+			// Converting a number with a CONVFMT that has an %s conversion
+			// would recurse forever, as %s converts using CONVFMT. Gawk and
+			// mawk produce an empty string here, so do the same.
+			return ""
+		}
+		// A format such as "%d" or "%c" that needs the number converted to
+		// something other than a float: hand it to sprintf.
+		return p.formatNum(f, num(n))
+	}
+	return numToStr(n, f.goFormat)
 }
 
 // Compile regex string (or fetch from regex cache)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -300,7 +300,7 @@ BEGIN {
 	{`BEGIN { print "The \u201cQUICK\u201d brown fox \u1F602" }  # !gawk`, "", "The “QUICK” brown fox 😂\n", "", ""},
 	{`{ print /foo/ }`, "food\nfoo\nxfooz\nbar\n", "1\n1\n1\n0\n", "", ""},
 	{`/[a-/`, "foo", "", "parse error at 1:1: error parsing regexp: invalid character class range: `a-)`", "terminated"},
-	{`/\Q/  # !gawk`, "", "", "parse error at 1:1: error parsing regexp: missing closing ): `(?s:\\Q)`", ""}, // Gawk produces a warning (not an error), so skip
+	{`/\Q/`, "", "", "parse error at 1:1: error parsing regexp: missing closing ): `(?s:\\Q)`", ""},
 	{`/=foo/`, "=foo", "=foo\n", "", ""},
 	{`BEGIN { RS="x" } /^a.*c$/`, "a\nb\nc", "a\nb\nc\n", "", ""},
 	{`BEGIN { print "-12"+0, "+12"+0, " \t\r\n7foo"+0, ".5"+0, "5."+0, "+."+0 }`, "", "-12 12 7 0.5 5 0\n", "", ""},
@@ -737,8 +737,6 @@ BEGIN {
 `, "", "1\n", "", ""},
 	{`BEGIN { print system("echo foo"); print system("echo bar") }  # !fuzz`,
 		"", "foo\n0\nbar\n0\n", "", ""},
-	{`BEGIN { print system(">&2 echo error") }  # !fuzz`,
-		"", "error\n0\n", "", ""},
 	{`BEGIN { print system("exit 42") }  # !fuzz !posix`, "", "42\n", "", ""},
 	{`BEGIN { system("cat") }`, "foo\nbar", "foo\nbar", "", ""},
 	{`BEGIN { print system("exec /bin/kill -9 $$") } # !awk !posix !windows`, "", "265\n", "", ""},
@@ -936,7 +934,6 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 	{`BEGIN { "echo foo" | getline a[1]; print a[1] }`, "", "foo\n", "", ""},
 	{`BEGIN { "echo foo" | getline $1; print $1 }`, "", "foo\n", "", ""},
 	{`BEGIN { print "foo" |"sort"; print "bar" |"sort" }  # !fuzz`, "", "bar\nfoo\n", "", ""},
-	{`BEGIN { print "foo" |">&2 echo error" }  # !gawk !fuzz`, "", "error\n", "", ""},
 	{`BEGIN { "cat" | getline; print }  # !fuzz`, "bar", "bar\n", "", ""},
 	{`BEGIN { print getline x < "/no/such/file" }  # !fuzz`, "", "-1\n", "", ""},
 	{`BEGIN { print getline "z"; print $0 }`, "foo", "1z\nfoo\n", "", ""},
@@ -981,7 +978,6 @@ BEGIN { x[1]=3; f5(x); print x[1] }
 	print $0
 }`, "", "foo\nbar\n", "", ""},
 	{`BEGIN { print "x" | "cat"; close("cat"); print "y" }`, "", "x\ny\n", "", ""},
-	{`BEGIN { print 1 >"/dev/stderr"; print 2 }  # !windows-gawk`, "", "1\n2\n", "", ""},
 
 	// Ensure data returned by getline (in various forms) is treated as numeric string
 	{`BEGIN { getline; print($0==0) }`, "0.0", "1\n", "", ""},
@@ -1227,21 +1223,26 @@ func TestInterp(t *testing.T) {
 				if test.in != "" {
 					cmd.Stdin = strings.NewReader(test.in)
 				}
-				out, err := cmd.CombinedOutput()
+				// Only stdout is compared, so warnings on stderr (such as
+				// newer Gawk's "bad `CONVFMT' specification") don't matter.
+				var stdout, stderr bytes.Buffer
+				cmd.Stdout = &stdout
+				cmd.Stderr = &stderr
+				err := cmd.Run()
 				if err != nil {
 					if test.awkErr != "" {
-						if strings.Contains(string(out), test.awkErr) {
+						if strings.Contains(stderr.String(), test.awkErr) {
 							return
 						}
-						t.Fatalf("expected error %q, got:\n%s", test.awkErr, out)
+						t.Fatalf("expected error %q, got:\n%s", test.awkErr, stderr.String())
 					} else {
-						t.Fatalf("error running %s: %v:\n%s", awkExe, err, out)
+						t.Fatalf("error running %s: %v:\n%s", awkExe, err, stderr.String())
 					}
 				}
 				if test.awkErr != "" {
 					t.Fatalf(`expected error %q, got ""`, test.awkErr)
 				}
-				normalized := normalizeNewlines(string(out))
+				normalized := normalizeNewlines(stdout.String())
 				if normalized != test.out {
 					t.Fatalf("expected/got:\n%q\n%q", test.out, normalized)
 				}
@@ -1735,6 +1736,46 @@ func TestShellCommand(t *testing.T) {
 			func(config *interp.Config) {
 				config.ShellCommand = []string{"foobar3982"}
 			})
+	}
+}
+
+// TestStderrOutput tests programs that write to stderr as well as stdout
+// (interpTests compares stdout only, and testGoAWK merges the two streams).
+func TestStderrOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		out  string
+		err  string
+	}{
+		{"system", `BEGIN { print system(">&2 echo error") }`, "0\n", "error\n"},
+		{"pipe", `BEGIN { print "foo" |">&2 echo error" }`, "", "error\n"},
+		{"redirect", `BEGIN { print 1 >"/dev/stderr"; print 2 }`, "2\n", "1\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip("skipping on Windows: these use Unix shell redirection")
+			}
+			prog, err := parser.ParseProgram([]byte(test.src), nil)
+			if err != nil {
+				t.Fatalf("error parsing: %v", err)
+			}
+			var outBuf, errBuf concurrentBuffer
+			_, err = interp.ExecProgram(prog, &interp.Config{
+				Output: &outBuf,
+				Error:  &errBuf,
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got := normalizeNewlines(outBuf.String()); got != test.out {
+				t.Errorf("expected stdout %q, got %q", test.out, got)
+			}
+			if got := normalizeNewlines(errBuf.String()); got != test.err {
+				t.Errorf("expected stderr %q, got %q", test.err, got)
+			}
+		})
 	}
 }
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -342,6 +342,32 @@ BEGIN {
 	CONVFMT = "%g"
 	print CONVFMT, 12345.678 ""
 }`, "", "%.6g 1.23457\n%.3g 1.23\n%g 12345.7\n", "", ""},
+	// A CONVFMT that isn't a plain float conversion still converts like other AWKs
+	{`BEGIN { CONVFMT = "%d"; print 1234.5678 "" }`, "", "1234\n", "", ""},
+	{`BEGIN { CONVFMT = "%i"; print 1234.5678 "" }`, "", "1234\n", "", ""},
+	{`BEGIN { CONVFMT = "%u"; print 1234.5678 "" }`, "", "1234\n", "", ""},
+	{`BEGIN { CONVFMT = "%x"; print 1234.5678 "" }`, "", "4d2\n", "", ""},
+	{`BEGIN { CONVFMT = "%o"; print 1234.5678 "" }`, "", "2322\n", "", ""},
+	{`BEGIN { CONVFMT = "%e"; print 1234.5678 "" }  # !windows-gawk`, "", "1.234568e+03\n", "", ""},
+	{`BEGIN { CONVFMT = "x%dy"; print 1234.5678 "" }`, "", "x1234y\n", "", ""},
+	{`BEGIN { CONVFMT = "abc"; print 1234.5678 "" }`, "", "abc\n", "", ""},
+	{`BEGIN { CONVFMT = ""; print "[" 1234.5678 "" "]" }`, "", "[]\n", "", ""},
+	{`BEGIN { CONVFMT = "%%"; print 1234.5678 "" }`, "", "%\n", "", ""},
+	// As with printf, our %c is byte-based unless -chars is given (like mawk, unlike Gawk)
+	{`BEGIN { CONVFMT = "%c"; print 1234.5678 "" }  # !gawk`, "", "\xd2\n", "", ""},
+	// An invalid conversion is used as a literal string, like Gawk (--posix Gawk is a fatal error)
+	{`BEGIN { CONVFMT = "%z"; print 1234.5678 "" }  # !posix`, "", "%z\n", "", ""},
+	// So is a format needing more than one argument (here Gawk is a fatal error either way)
+	{`BEGIN { CONVFMT = "%d %d"; print 1234.5678 "" }  # !awk !gawk`, "", "%d %d\n", "", ""},
+	// A CONVFMT with an %s conversion would recurse, as %s converts using CONVFMT.
+	// We produce an empty string; Gawk and mawk print nothing at all here.
+	{`BEGIN { CONVFMT = "%s"; print "[" 1234.5678 "" "]" }  # !awk !gawk`, "", "[]\n", "", ""},
+	{`BEGIN { CONVFMT = "x%sy"; print "[" 1234.5678 "" "]" }  # !awk !gawk`, "", "[]\n", "", ""},
+	// Integers and inf/nan never use CONVFMT
+	{`BEGIN { CONVFMT = "%c"; print 65 "" }`, "", "65\n", "", ""},
+	{`BEGIN { CONVFMT = "%d"; print log(0) "" }  # !awk !gawk`, "", "-inf\n", "", ""},
+	// CONVFMT is used for array subscripts too
+	{`BEGIN { CONVFMT = "%d"; a[1.5] = 1; for (k in a) print k }`, "", "1\n", "", ""},
 	{`BEGIN { FILENAME = "foo"; print FILENAME }`, "", "foo\n", "", ""},
 	{`BEGIN { FILENAME = "123.0"; print (FILENAME==123) }`, "", "0\n", "", ""},
 	// Other FILENAME behaviour is tested in goawk_test.go
@@ -374,6 +400,14 @@ BEGIN {
 	print OFMT, 0.666666666666
 }`, "", "%.6g 1.23457\n%.3g 1.23\n%G 0.666667\n", "", ""},
 	{`BEGIN { OFMT = "%e"; print OFMT, 12345.678 }  # !windows-gawk`, "", "%e 1.234568e+04\n", "", ""}, // Windows Gawk prints exponent as "+004"
+	// An OFMT that isn't a plain float conversion, as with CONVFMT above
+	{`BEGIN { OFMT = "%d"; print 1234.5678 }`, "", "1234\n", "", ""},
+	{`BEGIN { OFMT = "%x"; print 1234.5678 }`, "", "4d2\n", "", ""},
+	{`BEGIN { OFMT = "abc"; print 1234.5678 }`, "", "abc\n", "", ""},
+	{`BEGIN { OFMT = "%c"; print 65 }`, "", "65\n", "", ""}, // integers don't use OFMT
+	// Unlike CONVFMT, an %s conversion in OFMT is fine: it converts using CONVFMT
+	{`BEGIN { OFMT = "%s"; print 1234.5678 }`, "", "1234.57\n", "", ""},
+	{`BEGIN { OFMT = "%s"; CONVFMT = "%d"; print 1234.5678 }`, "", "1234\n", "", ""},
 	// OFS and ORS are tested above
 	{`BEGIN { print RSTART, RLENGTH; RSTART=5; RLENGTH=42; print RSTART, RLENGTH; } `, "",
 		"0 0\n5 42\n", "", ""},

--- a/interp/io.go
+++ b/interp/io.go
@@ -55,7 +55,7 @@ func (p *interp) printArgs(writer io.Writer, args []value) error {
 	case CSVMode, TSVMode:
 		fields := make([]string, 0, 7) // up to 7 args won't require a heap allocation
 		for _, arg := range args {
-			fields = append(fields, arg.str(p.outputFormatGo))
+			fields = append(fields, p.toOutputString(arg))
 		}
 		err := p.writeCSV(writer, fields)
 		if err != nil {
@@ -70,7 +70,7 @@ func (p *interp) printArgs(writer io.Writer, args []value) error {
 					return err
 				}
 			}
-			err := writeOutput(writer, arg.str(p.outputFormatGo), p.newlineOutputCRLF)
+			err := writeOutput(writer, p.toOutputString(arg), p.newlineOutputCRLF)
 			if err != nil {
 				return err
 			}

--- a/interp/newexecute.go
+++ b/interp/newexecute.go
@@ -132,10 +132,8 @@ func (p *interp) resetVars() {
 	}
 
 	// Reset special variables
-	p.convertFormat = "%.6g"
-	p.convertFormatGo = "%.6g"
-	p.outputFormat = "%.6g"
-	p.outputFormatGo = "%.6g"
+	p.convertFormat = defaultNumFormat
+	p.outputFormat = defaultNumFormat
 	p.fieldSep = " "
 	p.fieldSepRegex = nil
 	p.savedFieldSep = " "

--- a/interp/value.go
+++ b/interp/value.go
@@ -132,27 +132,39 @@ func parseFloat(s string) (float64, error) {
 // use floatFormat.
 func (v value) str(floatFormat string) string {
 	if v.typ == typeNum {
-		switch {
-		case math.IsNaN(v.n):
-			return "nan"
-		case math.IsInf(v.n, 0):
-			if v.n < 0 {
-				return "-inf"
-			} else {
-				return "inf"
-			}
-		case v.n == float64(int64(v.n)):
-			return strconv.FormatInt(int64(v.n), 10)
-		default:
-			if floatFormat == "%.6g" {
-				return strconv.FormatFloat(v.n, 'g', 6, 64)
-			}
-			return fmt.Sprintf(floatFormat, v.n)
-		}
+		return numToStr(v.n, floatFormat)
 	}
 	// For typeStr and typeNumStr we already have the string, for
 	// typeNull v.s == "".
 	return v.s
+}
+
+// Convert a number to a string using the given Go float format. Integers and
+// nan/inf are special cases and don't use floatFormat.
+func numToStr(n float64, floatFormat string) string {
+	switch {
+	case math.IsNaN(n):
+		return "nan"
+	case math.IsInf(n, 0):
+		if n < 0 {
+			return "-inf"
+		} else {
+			return "inf"
+		}
+	case n == float64(int64(n)):
+		return strconv.FormatInt(int64(n), 10)
+	case floatFormat == "%.6g": // speed up the default case
+		return strconv.FormatFloat(n, 'g', 6, 64)
+	default:
+		return fmt.Sprintf(floatFormat, n)
+	}
+}
+
+// Report whether converting the number n to a string actually applies CONVFMT
+// or OFMT: integers and nan/inf are converted without reference to the format
+// (as in other AWKs).
+func needsNumFormat(n float64) bool {
+	return !math.IsNaN(n) && !math.IsInf(n, 0) && n != float64(int64(n))
 }
 
 // Return value's number value, converting from string if necessary


### PR DESCRIPTION
This makes code like this:

```
$ goawk 'BEGIN { OFMT="%d"; print 1234.5678 }'
%!d(float64=1234.5678)
```

Work as expected (and as in other AWKs):

```
$ goawk 'BEGIN { OFMT="%d"; print 1234.5678 }'
1234
```