### PR TITLE
Make printf %s width and precision count bytes when not in -c mode

### DIFF
--- a/goawk.go
+++ b/goawk.go
@@ -59,7 +59,7 @@ const (
   -v var=value      variable assignment (multiple allowed)
 
 Additional GoAWK features:
-  -c                use Unicode chars for index, length, match, substr, and %c
+  -c                use Unicode chars for index, length, match, substr, %c, %s
   -E progfile       load program, treat as last option, disable var=value args
   -H                parse header row and enable @"field" in CSV input mode
   -h, --help        show this help message

--- a/interp/functions.go
+++ b/interp/functions.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"sort"
 	"strconv"
@@ -467,6 +468,48 @@ func (p *interp) formatNum(f numFormat, v value) string {
 	return s
 }
 
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// byteString formats itself like a plain string, except that %s width and
+// precision count bytes rather than Unicode characters (which is what Go's
+// fmt does). It's used for non-ASCII strings when not in chars mode, so that
+// "%.1s" truncates to the first byte, like awk in the C locale. (For ASCII
+// there's nothing to do: bytes and characters are the same thing.)
+type byteString string
+
+func (s byteString) Format(f fmt.State, verb rune) {
+	str := string(s)
+	if prec, ok := f.Precision(); ok && prec < len(str) {
+		str = str[:prec]
+	}
+	width, _ := f.Width() // zero if no width was given
+	if width <= len(str) {
+		io.WriteString(f, str)
+		return
+	}
+	// Note that fmt reports the '0' flag even when '-' is also present, but
+	// like Go's fmt (and C), zero padding only applies on the left.
+	pad := " "
+	if f.Flag('0') && !f.Flag('-') {
+		pad = "0"
+	}
+	padding := strings.Repeat(pad, width-len(str))
+	if f.Flag('-') {
+		io.WriteString(f, str)
+		io.WriteString(f, padding)
+	} else {
+		io.WriteString(f, padding)
+		io.WriteString(f, str)
+	}
+}
+
 // Guts of sprintf() function (also used by "printf" statement)
 func (p *interp) sprintf(format string, args []value) (string, error) {
 	format, types, err := p.parseFmtTypes(format)
@@ -482,7 +525,12 @@ func (p *interp) sprintf(format string, args []value) (string, error) {
 		var v any
 		switch t {
 		case 's':
-			v = p.toString(a)
+			str := p.toString(a)
+			if p.chars || isASCII(str) {
+				v = str
+			} else {
+				v = byteString(str)
+			}
 		case 'd':
 			v = int64(a.num())
 		case 'f':

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -316,7 +316,8 @@ type Config struct {
 	CSVOutput CSVOutputConfig
 
 	// Set to true to count using Unicode chars instead of bytes for
-	// index(), length(), match(), substr(), and printf %c.
+	// index(), length(), match(), substr(), printf %c, and the width and
+	// precision of printf %s.
 	Chars bool
 
 	// NewlineOutput specifies how newline characters are handled when writing

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -94,6 +94,11 @@ NR==3, NR==5 { print NR }
 	{`BEGIN { printf "%% %d %x %c %f %s", 42, 42, 42, 42, 42 }`, "", "% 42 2a * 42.000000 42", "", ""},
 	{`BEGIN { printf "%3d", 42 }`, "", " 42", "", ""},
 	{`BEGIN { printf "%3s", "x" }`, "", "  x", "", ""},
+	// Without -c, %s width and precision count bytes, not characters (gawk does the same under LC_ALL=C).
+	{`BEGIN { printf "%3s:%.1s", "╋", "╋" }  # !awk !gawk`, "", "╋:\xe2", "", ""},
+	{`BEGIN { printf "[%-4s]", "╋" }  # !awk !gawk`, "", "[╋ ]", "", ""},
+	{`BEGIN { printf "[%*.*s]", 4, 1, "╋" }  # !awk !gawk`, "", "[   \xe2]", "", ""}, // dynamic width and precision too
+	{`BEGIN { printf "[%06s][%-06s]", "╋", "╋" }  # !awk !gawk`, "", "[000╋][╋   ]", "", ""},
 	{`BEGIN { printf "%.1g", 42 }  # !windows-gawk`, "", "4e+01", "", ""}, // for some reason gawk gives "4e+001" on Windows
 	{`BEGIN { printf "%g", 12345.678 }`, "", "12345.7", "", ""},           // bare %g defaults to 6 significant digits (like C/awk)
 	{`BEGIN { printf "%G", 12345.678 }`, "", "12345.7", "", ""},
@@ -1667,6 +1672,9 @@ func TestCharsMode(t *testing.T) {
 		in  string
 		out string
 	}{
+		// printf %s
+		{`BEGIN { printf "%3s:%.1s", "╋", "╋" }`, "", "  ╋:╋"},
+
 		// printf %c
 		{`BEGIN { printf "%c", 128 }`, "", "\u0080"},
 		{`BEGIN { printf "%c", 255 }`, "", "ÿ"},


### PR DESCRIPTION
Addresses the `printf "%s"` part of #273. The regexp part is untouched, so this
shouldn't close the issue.

GoAWK counts bytes unless you pass `-c`, but Go's `fmt` always counts `%s` width
and precision in runes. So byte mode produced output that was bit-for-bit
identical to `-c` mode:

```
$ goawk    'BEGIN { printf "%3s:%.1s\n", "╋", "╋" }' | od -An -tx1
 20 20 e2 95 8b 3a e2 95 8b 0a
$ goawk -c 'BEGIN { printf "%3s:%.1s\n", "╋", "╋" }' | od -An -tx1
 20 20 e2 95 8b 3a e2 95 8b 0a
```

`LC_ALL=C gawk` gives the byte answer — width 3 is already satisfied by the
three-byte codepoint, and `.1` keeps just its first byte. That's the `od` output
avih posted in the thread:

```
 e2 95 8b 3a e2 0a
```

The `%c` case in `sprintf()` already branches on `p.chars`; this makes `%s` do
the same, by wrapping the argument in a small `fmt.Formatter` that truncates and
pads in bytes. Going through `Formatter` rather than rewriting the format string
is what keeps `%*s` and `%.*s` working — `fmt` resolves the `*` args before
calling `Format`, so the existing `sprintf("%*s %.*s", ...)` test still passes.
Zero-padding of `%03s` is unchanged (`fmt` reports the `0` flag to a `Formatter`
even when `-` is also present, hence the extra guard).

`%c` needs no equivalent change: it compiles to Go `%s` with a `[]byte`, and Go
counts runes there too, but in byte mode that slice is always exactly one byte
and in chars mode exactly one rune, so the two counts agree either way.

**Performance.** A `Formatter` costs a `defer` in `fmt.handleMethods`, and on
`BenchmarkPrintf` / `BenchmarkBuiltinSprintf` that showed up as a 15-25%
regression. Since byte counting and rune counting only ever disagree on
non-ASCII input, ASCII arguments now skip the wrapper entirely and take the
original path. Both benchmarks are back to baseline (within noise, allocations
identical), and only non-ASCII `%s` args pay anything:

```
                        before          after
BenchmarkPrintf         8412 ns/op      8386 ns/op    719 B/op   49 allocs/op
BenchmarkBuiltinSprintf 14550 ns/op    14825 ns/op   1080 B/op   75 allocs/op
```

**Tests.** Four rows in `interpTests` covering width, precision, left-align,
dynamic `%*.*s`, and zero-padding; all four fail on master. They're marked
`!awk !gawk` because the harness runs external awks under `LC_ALL=C.UTF-8`,
where the rune answer is the correct one. One row in `TestCharsMode` pins that
`-c` still counts characters. I also updated the `-c` help text and the
`Config.Chars` doc comment, which both enumerate what the flag affects.

I don't have gawk on this machine, so `go test ./...` was run with `-awk=` (all
packages green) and separately against onetrueawk with `-awk=awk`, where the
set of failures is identical before and after this change.

I used AI assistance (Claude) while writing this. The behaviour, the tests and
the benchmark runs are mine.